### PR TITLE
badly encoded file names could crash the program

### DIFF
--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -102,7 +102,12 @@ def list_existing_paths(directory, expected=(), ignored=(), follow_links=False):
     for path, _, files in os.walk(directory):
         for f in files:
             p = os.path.join(path, f)
-            p_uni = p.decode('utf8')
+            try:
+                p_uni = p.decode('utf8')
+            except UnicodeDecodeError as ex:
+                print("Unicode decode error for file, skipping:", file=sys.stderr, )
+                print(p, file=sys.stderr, )
+                continue
             try:
                 if follow_links or p_uni in expected:
                     st = os.stat(p)


### PR DESCRIPTION
Badly encoded file names could crash the program, and did not even tell the problematic file's filename.
Now, those files get skipped and their names written to stderr instead.
