### PR TITLE
Make bad files available in exception

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,5 +137,5 @@ Authors
 -------
 
 Glued together by `Łukasz Langa <mailto:lukasz@langa.pl>`_. Multiple
-improvements by `Yang Zhang <mailto:yaaang@gmail.com>`_ and `Jean-Louis
-Fuchs <mailto:ganwell@fangorn.ch>`_.
+improvements by `Yang Zhang <mailto:yaaang@gmail.com>`_, `Jean-Louis
+Fuchs <mailto:ganwell@fangorn.ch>`_ and `Phil Lundrigan <mailto:philipbl@cs.utah.edu>`_.

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -178,7 +178,7 @@ class Bitrot(object):
         new_paths = []
         updated_paths = []
         renamed_paths = []
-        error_count = 0
+        errors = []
         current_size = 0
         missing_paths = self.select_all_paths(cur)
         paths, total_size = list_existing_paths(
@@ -251,7 +251,7 @@ class Bitrot(object):
                 continue
 
             if stored_sha1 != new_sha1:
-                error_count += 1
+                errors.append(p)
                 print(
                     '\rerror: SHA1 mismatch for {}: expected {}, got {}.'
                     ' Last good hash checked on {}.'.format(
@@ -271,7 +271,7 @@ class Bitrot(object):
             self.report_done(
                 total_size,
                 all_count,
-                error_count,
+                len(errors),
                 new_paths,
                 updated_paths,
                 renamed_paths,
@@ -280,9 +280,9 @@ class Bitrot(object):
 
         update_sha512_integrity()
 
-        if error_count:
+        if len(errors) > 0:
             raise BitrotException(
-                1, 'There were {} errors found.'.format(error_count),
+                1, 'There were {} errors found.'.format(len(errors)), errors,
             )
 
     def select_all_paths(self, cur):

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -280,7 +280,7 @@ class Bitrot(object):
 
         update_sha512_integrity()
 
-        if len(errors) > 0:
+        if errors:
             raise BitrotException(
                 1, 'There were {} errors found.'.format(len(errors)), errors,
             )


### PR DESCRIPTION
I am writing a python script that checks for bitrot and emails me if it detects any. It would be nice to have the file names that were affected, so I added them to the exception.