### PR TITLE
Print full path when file name decoding fails

### DIFF
--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -115,7 +115,7 @@ def list_existing_paths(directory, expected=(), ignored=(), follow_links=False):
                 try:
                     print(
                         "warning: cannot decode file name:",
-                        path,
+                        p,
                         file=sys.stderr,
                     )
                 except UnicodeDecodeError:


### PR DESCRIPTION
`path` does not include `f`, so it might not show the actual file name which couldn't be decoded.