### PR TITLE
Corrected assumed 'utf-8' encoding

### DIFF
--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -186,7 +186,7 @@ class Bitrot(object):
         )
 
         for p in paths:
-            p_uni = p.decode('utf8')
+            p_uni = p.decode(FSENCODING)
             try:
                 st = os.stat(p)
             except OSError as ex:


### PR DESCRIPTION
Was failing on my machine - traced it to line 189 using a hard-coded 'utf-8' encoding. Everywhere else uses FSENCODING (which on my machine is 'mbcs'), so replaced it here as well.