### PR TITLE
File list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,8 @@ Change Log
 * bugfix: when using -q, don't hide warnings about files that can't be
   statted or read
 
+* bugfix: -s is no longer broken on Python 3
+
 0.9.0
 ~~~~~
 

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -42,7 +42,7 @@ import time
 
 DEFAULT_CHUNK_SIZE = 16384
 DOT_THRESHOLD = 200
-VERSION = (0, 9, 0)
+VERSION = (0, 9, 1)
 IGNORED_FILE_SYSTEM_ERRORS = {errno.ENOENT, errno.EACCES}
 FSENCODING = sys.getfilesystemencoding()
 
@@ -382,18 +382,20 @@ def get_path(directory=b'.', ext=b'db'):
     return os.path.join(directory, b'.bitrot.' + ext)
 
 
-def stable_sum(bitrot_db):
+def stable_sum(bitrot_db=None):
     """Calculates a stable SHA512 of all entries in the database.
 
     Useful for comparing if two directories hold the same data, as it ignores
     timing information."""
+    if bitrot_db is None:
+        bitrot_db = get_path()
     digest = hashlib.sha512()
     conn = get_sqlite3_cursor(bitrot_db)
     cur = conn.cursor()
     cur.execute('SELECT hash FROM bitrot ORDER BY path')
     row = cur.fetchone()
     while row:
-        digest.update(row[0])
+        digest.update(row[0].encode('ascii'))
         row = cur.fetchone()
     return digest.hexdigest()
 


### PR DESCRIPTION
Add a `--file-list` option to provide a file with a list of files to scan (one per line). Use `-` to get the list from stdin, which may be useful for piping output from other tools.

The file handle (or a handle to stdin) is passed to the `Bitrot` object, which is responsible for reading the list. I did it here (rather than pass the list) so that `Bitrot` can then work out a total size.

No provision for wildcards - this could be added too (but obviously it would be more complex, and it might be better handled by piping output from `ls` or `dir`).

Existing entries in the db that aren't on the list will be deleted. This may be desirable or not - depends on the use case I suppose. Might be worth adding another command-line flag to control this behaviour.