### PR TITLE
0.9.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Change Log
 * Added grammar fixes
 * Added a time elapsed counter
 * Added email support for hash mismatch
-* Added option to ignore date modified (only checks hashes). Great for verifying backups for integrity (File Integirty Monitoring)
+* Added option to ignore date modified (only checks hashes). Great for verifying backups for integrity (File Integrity Monitoring)
 * Added ability to specify hash function from command line. I found SHA512 to be just as fast as SHA1 on my machine
 * Total size now printed in B, KB, MB, GB, TB
 * Fixes for invalid characters in file names

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,19 @@ performance improvements, I'm accepting pull requests! :)
 Change Log
 ----------
 
+0.9.3
+~~~~~
+* Added logging to file
+* Added grammar fixes
+* Added a time elapsed counter
+* Added email support for hash mismatch
+* Added option to ignore date modified (only checks hashes). Great for verifying backups for integrity (File Integirty Monitoring)
+* Added ability to specify hash function from command line. I found SHA512 to be just as fast as SHA1 on my machine
+* Total size now printed in B, KB, MB, GB, TB
+* Fixes for invalid characters in file names
+* Better warning printing
+* Integrates benshep's and liloman's latest changes
+
 0.9.2
 ~~~~~
 

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -495,11 +495,11 @@ class Bitrot(object):
 
             if updated_paths:
                 if (len(updated_paths) == 1):
-                    print('1 entry updated:')
+                    print('\n1 entry updated:')
                     if (self.log):
                         writeToLog(stringToWrite='\n1 entry updated:')
                 else:
-                    print('{} entries updated:'.format(len(updated_paths)))
+                    print('\n{} entries updated:'.format(len(updated_paths)))
                     if (self.log):
                         writeToLog(stringToWrite='\n{} entries updated:'.format(len(updated_paths)))
 
@@ -511,11 +511,11 @@ class Bitrot(object):
 
             if renamed_paths:
                 if (len(renamed_paths) == 1):
-                    print('1 entry renamed:')
+                    print('\n1 entry renamed:')
                     if (self.log):
                         writeToLog(stringToWrite='\n1 entry renamed:')
                 else:
-                    print('{} entries renamed:'.format(len(renamed_paths)))
+                    print('\n{} entries renamed:'.format(len(renamed_paths)))
                     if (self.log):
                         writeToLog(stringToWrite='\n{} entries renamed:'.format(len(renamed_paths)))
 
@@ -534,11 +534,11 @@ class Bitrot(object):
                     
             if missing_paths:
                 if (len(missing_paths) == 1):
-                    print('1 entry missing:')
+                    print('\n1 entry missing:')
                     if (self.log):
                         writeToLog(stringToWrite='\n1 entry missing:')
                 else:
-                    print('{} entries missing:'.format(len(missing_paths)))
+                    print('\n{} entries missing:'.format(len(missing_paths)))
                     if (self.log):
                         writeToLog(stringToWrite='\n{} entries missing:'.format(len(missing_paths)))
 
@@ -548,7 +548,7 @@ class Bitrot(object):
                     if (self.log):
                         writeToLog(stringToWrite='\n {}'.format(path))
                         
-            if not any((new_paths, updated_paths, missing_paths)):
+            if not any((new_paths, updated_paths, missing_paths, renamed_paths)):
                 print()
         if self.test and self.verbosity:
             print('Database file not updated on disk (test mode).')

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -38,40 +38,59 @@ import stat
 import sys
 import tempfile
 import time
-
+import smtplib
+from fnmatch import fnmatch
+import email.utils
+from email.mime.text import MIMEText
+from datetime import timedelta
+#import re
 
 DEFAULT_CHUNK_SIZE = 16384  # block size in HFS+; 4X the block size in ext4
-DOT_THRESHOLD = 200
-VERSION = (0, 9, 2)
+DOT_THRESHOLD = 2
+VERSION = (0, 9, 3)
 IGNORED_FILE_SYSTEM_ERRORS = {errno.ENOENT, errno.EACCES}
 FSENCODING = sys.getfilesystemencoding()
-
+DEFAULT_HASH_FUNCTION = "SHA512"
 
 if sys.version[0] == '2':
     str = type(u'text')
     # use `bytes` for bytestrings
 
+def sendMail(stringToSend="", log=1, verbosity=1, subject=""):
+    msg = MIMEText(stringToSend)
 
-def sha1(path, chunk_size):
-    digest = hashlib.sha1()
-    with open(path, 'rb') as f:
-        d = f.read(chunk_size)
-        while d:
-            digest.update(d)
-            d = f.read(chunk_size)
-    return digest.hexdigest()
+    FROMADDR = 'author@gmail.com'
+    TOADDR  = 'recipient@gmail.com'
+    msg['To'] = email.utils.formataddr(('Recipient', 'recipient@gmail.com'))
+    msg['From'] = email.utils.formataddr(('Author', 'recipient@gmail.com'))
+    USERNAME = 'authorUsername'
+    PASSWORD = 'authorPassword'
 
+    try:
+        msg['Subject'] = subject
+        # The actual mail send
+        server = smtplib.SMTP('smtp.gmail.com:587')
+        server.starttls()
+        server.login(USERNAME,PASSWORD)
+        server.sendmail(FROMADDR, TOADDR, msg.as_string())
+        server.quit()
+    except Exception as err:
+        print('Email sending error:', err)
+        if (log):
+            writeToLog(stringToWrite='\n\nEmail sending error: {}'.format(err))
 
 def ts():
     return datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S%z')
-
 
 def get_sqlite3_cursor(path, copy=False):
     path = path.decode(FSENCODING)
     if copy:
         if not os.path.exists(path):
-            raise ValueError("error: bitrot database at {} does not exist."
+            raise ValueError("Error: bitrot database at {} does not exist."
                              "".format(path))
+            if (self.log):
+                writeToLog(stringToWrite="\nError: bitrot database at {} does not exist."
+                    "".format(path))
         db_copy = tempfile.NamedTemporaryFile(prefix='bitrot_', suffix='.db',
                                               delete=False)
         with open(path, 'rb') as db_orig:
@@ -93,8 +112,8 @@ def get_sqlite3_cursor(path, copy=False):
     atexit.register(conn.commit)
     return conn
 
-
-def list_existing_paths(directory, expected=(), ignored=(), follow_links=False):
+def list_existing_paths(directory, expected=(), ignored=(), 
+                        verbosity=1, follow_links=False, log=1):
     """list_existing_paths('/dir') -> ([path1, path2, ...], total_size)
 
     Returns a tuple with a list with existing files in `directory` and their
@@ -104,7 +123,7 @@ def list_existing_paths(directory, expected=(), ignored=(), follow_links=False):
     `follow_links` is False (the default).  All entries present in `expected`
     must be files (can't be directories or symlinks).
     """
-    paths = set()
+    paths = []
     total_size = 0
     for path, _, files in os.walk(directory):
         for f in files:
@@ -113,9 +132,12 @@ def list_existing_paths(directory, expected=(), ignored=(), follow_links=False):
                 p_uni = p.decode(FSENCODING)
             except UnicodeDecodeError:
                 binary_stderr = getattr(sys.stderr, 'buffer', sys.stderr)
-                binary_stderr.write(b"warning: cannot decode file name: ")
+                warnings.append(p)
+                binary_stderr.write(b"\rWarning: cannot decode file name: ")
                 binary_stderr.write(p)
                 binary_stderr.write(b"\n")
+                if (log):
+                    writeToLog(stringToWrite="\nWarning: cannot decode file name: {}".format(p))
                 continue
 
             try:
@@ -127,12 +149,19 @@ def list_existing_paths(directory, expected=(), ignored=(), follow_links=False):
                 if ex.errno not in IGNORED_FILE_SYSTEM_ERRORS:
                     raise
             else:
-                if not stat.S_ISREG(st.st_mode) or p in ignored:
-                    continue
-                paths.add(p)
-                total_size += st.st_size
-    return paths, total_size
+                if not stat.S_ISREG(st.st_mode) or any([fnmatch(p, exc) for exc in ignored]):
+                    if verbosity > 2:
+                        #print('Ignoring file: {}'.format(p))
+                        print('Ignoring file: {}'.format(p.decode(FSENCODING)))
+                        if (log):
+                            #writeToLog(stringToWrite="\nIgnoring file: {}".format(p))
+                            writeToLog(stringToWrite="\nIgnoring file: {}".format(p.decode(FSENCODING)))
 
+                    continue
+                paths.append(p)
+                total_size += st.st_size
+    paths.sort()
+    return paths, total_size
 
 class BitrotException(Exception):
     pass
@@ -140,16 +169,23 @@ class BitrotException(Exception):
 
 class Bitrot(object):
     def __init__(
-        self, verbosity=1, test=False, follow_links=False, commit_interval=300,
-        chunk_size=DEFAULT_CHUNK_SIZE,
+        self, verbosity=1, email = False, log = False, test=False, follow_links=False, commit_interval=300,
+        chunk_size=DEFAULT_CHUNK_SIZE, file_list=None, exclude_list=[],  no_time=False, hashing_function=""
     ):
         self.verbosity = verbosity
         self.test = test
         self.follow_links = follow_links
         self.commit_interval = commit_interval
         self.chunk_size = chunk_size
+        self.file_list = file_list
+        self.exclude_list = exclude_list
         self._last_reported_size = ''
         self._last_commit_ts = 0
+        self.email = email
+        self.log = log
+        self.no_time = no_time
+        self.startTime = time.clock()
+        self.hashing_function = hashing_function
 
     def maybe_commit(self, conn):
         if time.time() < self._last_commit_ts + self.commit_interval:
@@ -160,10 +196,12 @@ class Bitrot(object):
         self._last_commit_ts = time.time()
 
     def run(self):
-        check_sha512_integrity(verbosity=self.verbosity)
+        check_sha512_integrity(verbosity=self.verbosity, log=self.log)
 
-        bitrot_db = get_path()
         bitrot_sha512 = get_path(ext=b'sha512')
+        bitrot_log = get_path(ext=b'log')
+        bitrot_db = get_path()
+      
         try:
             conn = get_sqlite3_cursor(bitrot_db, copy=self.test)
         except ValueError:
@@ -171,21 +209,32 @@ class Bitrot(object):
                 2,
                 'No database exists so cannot test. Run the tool once first.',
             )
+            if (self.log):
+                writeToLog(stringToWrite="\nNo database exists so cannot test. Run the tool once first.")
 
         cur = conn.cursor()
         new_paths = []
         updated_paths = []
         renamed_paths = []
         errors = []
+        warnings = []
         current_size = 0
         missing_paths = self.select_all_paths(cur)
-        hashes = self.select_all_hashes(cur)
-        paths, total_size = list_existing_paths(
-            b'.', expected=missing_paths, ignored={bitrot_db, bitrot_sha512},
-            follow_links=self.follow_links,
-        )
+        if self.file_list:
+            paths = [line.rstrip('\n').encode(FSENCODING)
+                for line in self.file_list.readlines()]
+            total_size = sum([os.path.getsize(filename) for filename in paths])
+        else:
+            paths, total_size = list_existing_paths(
+                b'.', expected=missing_paths, 
+                ignored=[bitrot_db, bitrot_sha512,bitrot_log] + self.exclude_list,
+                follow_links=self.follow_links,
+                verbosity=self.verbosity,
+                log=self.log
+            )
 
-        for p in sorted(paths):
+
+        for p in paths:
             p_uni = p.decode(FSENCODING)
             try:
                 st = os.stat(p)
@@ -194,13 +243,18 @@ class Bitrot(object):
                     # The file disappeared between listing existing paths and
                     # this run or is (temporarily?) locked with different
                     # permissions. We'll just skip it for now.
+                    warnings.append(p)
                     print(
-                        '\rwarning: `{}` is currently unavailable for '
+                        '\rWarning: `{}` is currently unavailable for '
                         'reading: {}'.format(
-                            p_uni, ex,
+                            #p_uni, ex,
+                            p.decode(FSENCODING), ex,
                         ),
                         file=sys.stderr,
                     )
+                    if (self.log):
+                        #writeToLog(stringToWrite='\nWarning: `{}` is currently unavailable for reading: {}'.format(p_uni, ex))
+                        writeToLog(stringToWrite='\nWarning: `{}` is currently unavailable for reading: {}'.format(p.decode(FSENCODING), ex))
                     continue
 
                 raise   # Not expected? https://github.com/ambv/bitrot/issues/
@@ -208,18 +262,24 @@ class Bitrot(object):
             new_mtime = int(st.st_mtime)
             current_size += st.st_size
             if self.verbosity:
-                self.report_progress(current_size, total_size)
+                self.report_progress(current_size, total_size, p_uni)
 
             missing_paths.discard(p_uni)
             try:
-                new_sha1 = sha1(p, self.chunk_size)
+                new_hash = hash(p, self.chunk_size,self.hashing_function,log=self.log)
             except (IOError, OSError) as e:
+                warnings.append(p)
                 print(
-                    '\rwarning: cannot compute hash of {} [{}]'.format(
-                        p, errno.errorcode[e.args[0]],
+                    '\rWarning: cannot compute hash of {} [{}]'.format(
+                        #p, errno.errorcode[e.args[0]],
+                        p.decode(FSENCODING),errno.errorcode[e.args[0]],
                     ),
                     file=sys.stderr,
                 )
+                if (self.log):
+                    writeToLog(stringToWrite='\n\nWarning: cannot compute hash of {} [{}]'.format(
+                            #p, errno.errorcode[e.args[0]]))
+                            p.decode(FSENCODING), errno.errorcode[e.args[0]]))
                 continue
 
             cur.execute('SELECT mtime, hash, timestamp FROM bitrot WHERE '
@@ -227,36 +287,45 @@ class Bitrot(object):
             row = cur.fetchone()
             if not row:
                 stored_path = self.handle_unknown_path(
-                    cur, p_uni, new_mtime, new_sha1, paths, hashes
+                    cur, p_uni, new_mtime, new_hash
                 )
                 self.maybe_commit(conn)
 
                 if p_uni == stored_path:
-                    new_paths.append(p)   # FIXME: shouldn't that be p_uni?
+                    new_paths.append(p)   # FIXME: shouldn't that be p_uni instead of p?
                 else:
                     renamed_paths.append((stored_path, p_uni))
                     missing_paths.discard(stored_path)
                 continue
-
-            stored_mtime, stored_sha1, stored_ts = row
-            if int(stored_mtime) != new_mtime:
+            stored_mtime, stored_hash, stored_ts = row
+            if (int(stored_mtime) != new_mtime) and (self.no_time == False):
                 updated_paths.append(p)
                 cur.execute('UPDATE bitrot SET mtime=?, hash=?, timestamp=? '
                             'WHERE path=?',
-                            (new_mtime, new_sha1, ts(), p_uni))
+                            (new_mtime, new_hash, ts(), p_uni))
                 self.maybe_commit(conn)
                 continue
-
-            if stored_sha1 != new_sha1:
+            if stored_hash != new_hash:
                 errors.append(p)
+
                 print(
-                    '\rerror: SHA1 mismatch for {}: expected {}, got {}.'
-                    ' Last good hash checked on {}.'.format(
-                        p, stored_sha1, new_sha1, stored_ts
+                    '\rError: {} mismatch for {}\nExpected: {}\nGot:      {}'
+                    '\nLast good hash checked on {}\n'.format(
+                    #p, stored_hash, new_hash, stored_ts
+                    self.hashing_function,p.decode(FSENCODING), stored_hash, new_hash, stored_ts
                     ),
                     file=sys.stderr,
                 )
-
+                if (self.log):
+                    writeToLog(stringToWrite=
+                        '\n\nError: {} mismatch for {}\nExpected: {}\nGot:          {}'
+                        '\nLast good hash checked on {}'.format(
+                        #p, stored_hash, new_hash, stored_ts
+                        self.hashing_function,p.decode(FSENCODING), stored_hash, new_hash, stored_ts))
+                if (self.email):
+                        sendMail('Error {} mismatch for {} \nExpected {}\nGot          {}\nLast good hash checked on {}'.format(self.hashing_function,p.decode(FSENCODING),
+                        stored_hash,new_hash,stored_ts),log=self.log,verbosity=self.verbosity, subject="FIM Error")
+                    
         for path in missing_paths:
             cur.execute('DELETE FROM bitrot WHERE path=?', (path,))
 
@@ -269,18 +338,37 @@ class Bitrot(object):
                 total_size,
                 all_count,
                 len(errors),
+                len(warnings),
                 new_paths,
                 updated_paths,
                 renamed_paths,
                 missing_paths,
             )
 
-        update_sha512_integrity(verbosity=self.verbosity)
+        update_sha512_integrity(verbosity=self.verbosity, log=self.log)
+
+        if self.verbosity:
+            recordTimeElapsed(startTime = self.startTime, log = self.log)
+
+        if warnings:
+            if len(warnings) == 1:
+                print('Warning: There was 1 warning found.')
+                if (self.log):
+                    writeToLog(stringToWrite='\nWarning: There was 1 warning found.')
+            else:
+                print('Warning: There were {} warnings found.'.format(len(warnings)))
+                if (self.log):
+                    writeToLog(stringToWrite='\nWarning: There were {} warnings found.'.format(len(warnings)))
 
         if errors:
-            raise BitrotException(
-                1, 'There were {} errors found.'.format(len(errors)), errors,
-            )
+            if len(errors) == 1:
+                raise BitrotException(
+                    1, 'There was 1 error found.',
+                )
+            else:
+                raise BitrotException(
+                    1, 'There were {} errors found.'.format(len(errors)), errors,
+                )
 
     def select_all_paths(self, cur):
         result = set()
@@ -291,96 +379,202 @@ class Bitrot(object):
             row = cur.fetchone()
         return result
 
-    def select_all_hashes(self, cur):
-        result = {}
-        cur.execute('SELECT hash, path FROM bitrot')
-        row = cur.fetchone()
-        while row: 
-            rhash, rpath = row
-            result.setdefault(rhash, set()).add(rpath)
-            row = cur.fetchone()
-        return result
-
-    def report_progress(self, current_size, total_size):
+    def report_progress(self, current_size, total_size, current_path):
         size_fmt = '\r{:>6.1%}'.format(current_size/(total_size or 1))
         if size_fmt == self._last_reported_size:
             return
 
-        sys.stdout.write(size_fmt)
+        # show current file in progress too
+        terminal_size = shutil.get_terminal_size()
+        # but is it too big for terminal window?
+        cols = terminal_size.columns
+        max_path_size = cols - len(size_fmt) - 1
+
+        #without this line, weird character in the filename could cause strange printing output
+        current_path = cleanString(stringToClean=current_path)
+
+        if len(current_path) > max_path_size:
+            # show first half and last half, separated by ellipsis
+            # e.g. averylongpathnameaveryl...ameaverylongpathname
+            half_mps = (max_path_size - 3) // 2
+            current_path = current_path[:half_mps] + '...' + current_path[-half_mps:]
+        else:
+            # pad out with spaces, otherwise previous filenames won't be erased
+            current_path += ' ' * (max_path_size - len(current_path))
+            
+        sys.stdout.write(size_fmt + ' ' + current_path)
         sys.stdout.flush()
         self._last_reported_size = size_fmt
 
+
     def report_done(
-        self, total_size, all_count, error_count, new_paths, updated_paths,
+        self, total_size, all_count, error_count, warning_count, new_paths, updated_paths,
         renamed_paths, missing_paths):
-        print('\rFinished. {:.2f} MiB of data read. {} errors found.'
-            ''.format(total_size/1024/1024, error_count))
+
+        sizeUnits , total_size = calculateUnits(total_size=total_size)
+
+        if (error_count == 1):
+                print('\rFinished. {:.2f} {} of data read. 1 error found. '.format(total_size,sizeUnits),end="")
+                if (self.log):
+                    writeToLog(stringToWrite='\n\nFinished. {:.2f} {} of data read. '.format(total_size,sizeUnits))
+        else:
+            print('\rFinished. {:.2f} {} of data read. {} errors found. '.format(total_size, sizeUnits, error_count),end="")
+            if (self.log):
+                writeToLog(stringToWrite='\n\nFinished. {:.2f} MiB of data read. {} errors found. '.format(total_size, error_count, sizeUnits))
+
+        if (warning_count == 1):
+            print('1 warning found.')
+            if (self.log):
+                writeToLog(stringToWrite='1 warning found')
+        else:
+            print('{} warnings found.'.format(warning_count))
+            if (self.log):
+                writeToLog(stringToWrite='{} warnings found.'.format(warning_count))
+
         if self.verbosity == 1:
-            print(
+            if (all_count == 1):
+                print(
+                    '1 entry in the database, {} new, {} updated, '
+                    '{} renamed, {} missing.'.format(
+                        len(new_paths), len(updated_paths),
+                        len(renamed_paths), len(missing_paths)))
+                if (self.log):
+                    writeToLog(stringToWrite=
+                    '\n1 entry in the database, {} new, {} updated, '
+                    '{} renamed, {} missing.'.format(
+                        len(new_paths), len(updated_paths),
+                        len(renamed_paths), len(missing_paths)))
+            else:
+                print(
                 '{} entries in the database, {} new, {} updated, '
                 '{} renamed, {} missing.'.format(
                     all_count, len(new_paths), len(updated_paths),
-                    len(renamed_paths), len(missing_paths),
-                ),
-            )
+                    len(renamed_paths), len(missing_paths)))
+                if (self.log):
+                    writeToLog(stringToWrite=
+                    '\n{} entries in the database, {} new, {} updated, '
+                    '{} renamed, {} missing.'.format(
+                        all_count, len(new_paths), len(updated_paths),
+                        len(renamed_paths), len(missing_paths)))
+
         elif self.verbosity > 1:
-            print('{} entries in the database.'.format(all_count), end=' ')
+            if (all_count == 1):
+                print('1 entry in the database.')
+                if (self.log):
+                    writeToLog(stringToWrite='1 entry in the database.')
+            else:
+                print('{} entries in the database.'.format(all_count), end=' ')
+                if (self.log):
+                    writeToLog(stringToWrite='\n{} entries in the database.'.format(all_count))
+
             if new_paths:
-                print('{} entries new:'.format(len(new_paths)))
+                if (len(new_paths) == 1):
+                    print('\n1 new entry:')
+                    if (self.log):
+                        writeToLog(stringToWrite='\n1 new entry:')
+                else:
+                    print('\n{} new entries:'.format(len(new_paths)))
+                    if (self.log):
+                        writeToLog(stringToWrite='\n{} new entries:'.format(len(new_paths)))
+
                 new_paths.sort()
                 for path in new_paths:
                     print(' ', path.decode(FSENCODING))
+                    if (self.log):
+                        writeToLog(stringToWrite='\n {}'.format(path.decode(FSENCODING)))
+
             if updated_paths:
-                print('{} entries updated:'.format(len(updated_paths)))
+                if (len(updated_paths) == 1):
+                    print('1 entry updated:')
+                    if (self.log):
+                        writeToLog(stringToWrite='\n1 entry updated:')
+                else:
+                    print('{} entries updated:'.format(len(updated_paths)))
+                    if (self.log):
+                        writeToLog(stringToWrite='\n{} entries updated:'.format(len(updated_paths)))
+
                 updated_paths.sort()
                 for path in updated_paths:
                     print(' ', path.decode(FSENCODING))
+                    if (self.log):
+                        writeToLog(stringToWrite='\n {}'.format(path.decode(FSENCODING)))
+
             if renamed_paths:
-                print('{} entries renamed:'.format(len(renamed_paths)))
+                if (len(renamed_paths) == 1):
+                    print('1 entry renamed:')
+                    if (self.log):
+                        writeToLog(stringToWrite='\n1 entry renamed:')
+                else:
+                    print('{} entries renamed:'.format(len(renamed_paths)))
+                    if (self.log):
+                        writeToLog(stringToWrite='\n{} entries renamed:'.format(len(renamed_paths)))
+
                 renamed_paths.sort()
                 for path in renamed_paths:
                     print(
-                        ' from',
-                        path[0].decode(FSENCODING),
+                        '  from',
+                        #path[0].decode(FSENCODING),
+                        path[0],
                         'to',
-                        path[1].decode(FSENCODING),
+                        #path[1].decode(FSENCODING),
+                        path[1],
                     )
+                    if (self.log):
+                        writeToLog(stringToWrite='\n from {} to {}'.format(path[0],path[1]))
+                    
             if missing_paths:
-                print('{} entries missing:'.format(len(missing_paths)))
+                if (len(missing_paths) == 1):
+                    print('1 entry missing:')
+                    if (self.log):
+                        writeToLog(stringToWrite='\n1 entry missing:')
+                else:
+                    print('{} entries missing:'.format(len(missing_paths)))
+                    if (self.log):
+                        writeToLog(stringToWrite='\n{} entries missing:'.format(len(missing_paths)))
+
                 missing_paths = sorted(missing_paths)
                 for path in missing_paths:
                     print(' ', path)
+                    if (self.log):
+                        writeToLog(stringToWrite='\n {}'.format(path))
+                        
             if not any((new_paths, updated_paths, missing_paths)):
                 print()
         if self.test and self.verbosity:
-            print('warning: database file not updated on disk (test mode).')
+            print('Database file not updated on disk (test mode).')
+            if (self.log):
+                writeToLog(stringToWrite='\nDatabase file not updated on disk (test mode).')
 
-    def handle_unknown_path(self, cur, new_path, new_mtime, new_sha1, paths, hashes):
+    def handle_unknown_path(self, cur, new_path, new_mtime, new_sha1):
         """Either add a new entry to the database or update the existing entry
         on rename.
 
         Returns `new_path` if the entry was indeed new or the `stored_path` (e.g.
         outdated path) if there was a rename.
         """
+        cur.execute('SELECT mtime, path, timestamp FROM bitrot WHERE hash=?',
+                    (new_sha1,))
+        rows = cur.fetchall()
+        for row in rows:
+            stored_mtime, stored_path, stored_ts = row
+            if os.path.exists(stored_path):
+                # file still exists, move on
+                continue
 
-        try: # if the path isn't in the database
-            found = [path for path in hashes[new_sha1] if path not in paths]
-            renamed = found.pop()
             # update the path in the database
             cur.execute(
                 'UPDATE bitrot SET mtime=?, path=?, timestamp=? WHERE path=?',
-                (new_mtime, new_path, ts(), renamed),
+                (new_mtime, new_path, ts(), stored_path),
             )
 
-            return renamed
-        
-        # From hashes[new_sha1] or found.pop() 
-        except (KeyError,IndexError):
-            cur.execute(
-                'INSERT INTO bitrot VALUES (?, ?, ?, ?)',
-                (new_path, new_mtime, new_sha1, ts()),
-            )
-            return new_path
+            return stored_path
+
+        # no rename, just a new file with the same hash
+        cur.execute(
+            'INSERT INTO bitrot VALUES (?, ?, ?, ?)',
+            (new_path, new_mtime, new_sha1, ts()),
+        )
+        return new_path
 
 def get_path(directory=b'.', ext=b'db'):
     """Compose the path to the selected bitrot file."""
@@ -404,49 +598,71 @@ def stable_sum(bitrot_db=None):
         row = cur.fetchone()
     return digest.hexdigest()
 
-
-def check_sha512_integrity(verbosity=1):
+def check_sha512_integrity(verbosity=1, log=1):
     sha512_path = get_path(ext=b'sha512')
     if not os.path.exists(sha512_path):
         return
 
+    bitrot_db = get_path()
+    if not os.path.exists(bitrot_db):
+        return
+
     if verbosity:
         print('Checking bitrot.db integrity... ', end='')
+        if (log):
+            writeToLog(stringToWrite='\nChecking bitrot.db integrity... ')
         sys.stdout.flush()
     with open(sha512_path, 'rb') as f:
         old_sha512 = f.read().strip()
-    bitrot_db = get_path()
+    
     digest = hashlib.sha512()
     with open(bitrot_db, 'rb') as f:
         digest.update(f.read())
     new_sha512 = digest.hexdigest().encode('ascii')
     if new_sha512 != old_sha512:
-        if verbosity:
-            if len(old_sha512) == 128:
-                print(
-                    "error: SHA512 of the file is different, bitrot.db might "
-                    "be corrupt.",
-                )
-            else:
-                print(
-                    "error: SHA512 of the file is different but bitrot.sha512 "
-                    "has a suspicious length. It might be corrupt.",
-                )
+        if len(old_sha512) == 128:
             print(
-                "If you'd like to continue anyway, delete the .bitrot.sha512 "
-                "file and try again.",
-                file=sys.stderr,
+                "\nError: SHA512 of the database file is different, bitrot.db might "
+                "be corrupt.",
             )
+            if (log):
+                writeToLog(stringToWrite=
+                "\nError: SHA512 of the database file is different, bitrot.db might "
+                "be corrupt.",
+            )
+        else:
+            print(
+                "\nError: SHA512 of the database file is different, but bitrot.sha512 "
+                "has a suspicious length. It might be corrupt.",
+            )
+            if (log):
+                writeToLog(stringToWrite=
+                "\nError: SHA512 of the database file is different, but bitrot.sha512 "
+                "has a suspicious length. It might be corrupt.",
+            )
+        print(
+            "If you'd like to continue anyway, delete the .bitrot.sha512 "
+            "file and try again.",
+            file=sys.stderr,
+        )
+        if (log):
+            writeToLog(stringToWrite=
+            "\nIf you'd like to continue anyway, delete the .bitrot.sha512 file and try again.")
+            writeToLog(stringToWrite="\nbitrot.db integrity check failed, cannot continue.")
+
         raise BitrotException(
             3, 'bitrot.db integrity check failed, cannot continue.',
         )
 
     if verbosity:
         print('ok.')
+        if (log):
+            writeToLog(stringToWrite='ok.')
 
-def update_sha512_integrity(verbosity=1):
+def update_sha512_integrity(verbosity=1, log=1):
     old_sha512 = 0
     sha512_path = get_path(ext=b'sha512')
+
     if os.path.exists(sha512_path):
         with open(sha512_path, 'rb') as f:
             old_sha512 = f.read().strip()
@@ -458,15 +674,132 @@ def update_sha512_integrity(verbosity=1):
     if new_sha512 != old_sha512:
         if verbosity:
             print('Updating bitrot.sha512... ', end='')
+            if (log):
+                writeToLog(stringToWrite='\nUpdating bitrot.sha512... ')
             sys.stdout.flush()
         with open(sha512_path, 'wb') as f:
             f.write(new_sha512)
         if verbosity:
             print('done.')
+            if (log):
+                writeToLog(stringToWrite='done.')
+
+def recordTimeElapsed(startTime=0, log=1):
+    elapsedTime = (time.clock() - startTime)  
+    if (elapsedTime > 3600):
+        elapsedTime /= 3600
+        if ((int)(elapsedTime) == 1):
+            print('Time elapsed: 1 hour.')
+            if (log):
+                writeToLog(stringToWrite='\nTime elapsed: 1 hour.')
+        else:
+            print('Time elapsed: {:.1f} hours.'.format(elapsedTime))
+            if (log):
+                writeToLog(stringToWrite='\nTime elapsed: {:.1f} hours.'.format(elapsedTime))
+
+    elif (elapsedTime > 60):
+        elapsedTime /= 60
+        if ((int)(elapsedTime) == 1):
+            print('Time elapsed: 1 minute.')
+            if (log):
+                writeToLog(stringToWrite='\nTime elapsed: 1 minute.')
+        else:
+            print('Time elapsed: {:.0f} minutes.'.format(elapsedTime))
+            if (log):
+                writeToLog(stringToWrite='\nTime elapsed: {:.0f} minutes.'.format(elapsedTime))
+
+    else:
+        if ((int)(elapsedTime) == 1):
+            print('Time elapsed: 1 second.')
+            if (log):
+                writeToLog(stringToWrite='\nTime elapsed: 1 second.')
+        else:
+            print('Time elapsed: {:.0f} seconds.'.format(elapsedTime))
+            if (log):
+                 writeToLog(stringToWrite='\nTime elapsed: {:.1f} seconds.'.format(elapsedTime))
+
+def isValidHashingFunction(stringToValidate=""):
+    if  (stringToValidate == "SHA1"
+      or stringToValidate == "SHA224"
+      or stringToValidate == "SHA384"
+      or stringToValidate == "SHA256"
+      or stringToValidate == "SHA512"
+      or stringToValidate == "MD5"):
+        return True
+    else:
+        return False
+
+def calculateUnits(total_size = 0):
+        if (total_size/1024/1024/1024/1024/1024/1024/1024/1024 >= 1):
+            sizeUnits = "YB"
+            total_size = total_size/1024/1024/1024/1024/1024/1024/1024/1024
+        elif (total_size/1024/1024/1024/1024/1024/1024/1024 >= 1):
+            sizeUnits = "ZB"
+            total_size = total_size/1024/1024/1024/1024/1024/1024/1024
+        elif (total_size/1024/1024/1024/1024/1024/1024 >= 1):
+            sizeUnits = "EB"
+            total_size = total_size/1024/1024/1024/1024/1024/1024
+        elif (total_size/1024/1024/1024/1024/1024 >= 1):
+            sizeUnits = "PB"
+            total_size = total_size/1024/1024/1024/1024/1024
+        elif (total_size/1024/1024/1024/1024 >= 1):
+            sizeUnits = "TB"
+            total_size = total_size/1024/1024/1024/1024
+        elif (total_size/1024/1024/1024 >= 1):
+            sizeUnits = "GB"
+            total_size = total_size/1024/1024/1024
+        elif (total_size/1024/1024 >= 1):
+            sizeUnits = "MB"
+            total_size = total_size/1024/1024
+        elif (total_size/1024 >= 1):
+            sizeUnits = "KB"
+            total_size = total_size/1024
+        else:
+            sizeUnits = "B"
+            total_size = total_size
+        return sizeUnits, total_size
+
+def writeToLog(stringToWrite=""):
+    log_path = get_path(ext=b'log')
+    stringToWrite = cleanString(stringToWrite)
+    with open(log_path, 'a') as logFile:
+        logFile.write(stringToWrite)
+        logFile.close()
+
+
+def cleanString(stringToClean=""):
+    #stringToClean=re.sub(r'[\\/*?:"<>|]',"",stringToClean)
+    stringToClean = ''.join([x for x in stringToClean if ord(x) < 128])
+    return stringToClean
+
+def hash(path, chunk_size,hashing_function="",log=1):
+    if (hashing_function.upper() == "MD5"):
+        digest=hashlib.md5()
+    elif (hashing_function.upper() == "SHA1"):
+        digest=hashlib.sha1()
+    elif (hashing_function.upper() == "SHA224"):
+        digest=hashlib.sha224()
+    elif (hashing_function.upper() == "SHA384"):
+        digest=hashlib.sha384()
+    elif (hashing_function.upper() == "SHA256"):
+        digest=hashlib.sha256()
+    elif (hashing_function.upper() == "SHA512"):
+        digest=hashlib.sha512() 
+    else:
+        #You should never get here
+        if (log):
+            writeToLog(stringToWrite='\nInvalid hash function detected.')
+        raise Exception('Invalid hash function detected.')
+
+    with open(path, 'rb') as f:
+        d = f.read(chunk_size)
+        while d:
+            digest.update(d)
+            d = f.read(chunk_size)
+    return digest.hexdigest()
 
 def run_from_command_line():
     global FSENCODING
-
     parser = argparse.ArgumentParser(prog='bitrot')
     parser.add_argument(
         '-l', '--follow-links', action='store_true',
@@ -477,19 +810,10 @@ def run_from_command_line():
              'symbolic links registered during the first run will be '
              'properly followed and checked even if you run without `-l`.')
     parser.add_argument(
-        '-q', '--quiet', action='store_true',
-        help='don\'t print anything besides checksum errors')
-    parser.add_argument(
         '-s', '--sum', action='store_true',
         help='using only the data already gathered, return a SHA-512 sum '
              'of hashes of all the entries in the database. No timestamps '
              'are used in calculation.')
-    parser.add_argument(
-        '-v', '--verbose', action='store_true',
-        help='list new, updated and missing entries')
-    parser.add_argument(
-        '-t', '--test', action='store_true',
-        help='just test against an existing database, don\'t update anything')
     parser.add_argument(
         '--version', action='version',
         version='%(prog)s {}.{}.{}'.format(*VERSION))
@@ -504,6 +828,34 @@ def run_from_command_line():
         '--fsencoding', default='',
         help='override the codec to decode filenames, otherwise taken from '
              'the LANG environment variables')
+    parser.add_argument(
+        '-f', '--file-list', default='',
+        help='only read the files listed in this file (use - for stdin)')
+    parser.add_argument(
+        '-t', '--test', action='store_true',
+        help='just test against an existing database, don\'t update anything')
+    parser.add_argument(
+        '-a', '--hashing-function', default='',
+        help='Doesnt compare dates, only hashes. Also enables test-only mode')
+    parser.add_argument(
+        '-x', '--exclude-list', default='',
+        help="don't read the files listed in this file - wildcards are allowed")
+    parser.add_argument(
+        '-v', '--verbose', default=1,
+        help='Level 0: Don\'t print anything besides checksum errors.\n'
+        'Level 1: Normal amount of verbosity.\n'
+        'Level 2: List new, updated and missing entries.\n'
+        'Level 3: List new, updated and missing entries, and ignored files.\n')
+    parser.add_argument(
+        '-n', '--no-time', action='store_true',
+        help='Doesnt compare dates, only hashes. Also enables test-only mode')
+    parser.add_argument(
+        '-e', '--email', action='store_true',
+        help='email file integirty errors')
+    parser.add_argument(
+        '-g', '--log', action='store_true',
+        help='logs activity')
+
     args = parser.parse_args()
     if args.sum:
         try:
@@ -511,26 +863,100 @@ def run_from_command_line():
         except RuntimeError as e:
             print(str(e).encode('utf8'), file=sys.stderr)
     else:
-        verbosity = 1
-        if args.quiet:
-            verbosity = 0
-        elif args.verbose:
-            verbosity = 2
+        if args.verbose:
+            verbosity = int(args.verbose)
+            if (verbosity != 0 and verbosity != 1 and verbosity != 2 and verbosity != 3):
+                verbosity = 1
+
+        if (args.log):
+            log_path = get_path(ext=b'log')
+            if (verbosity):
+                if os.path.exists(log_path):
+                    writeToLog(stringToWrite='\n')
+                    writeToLog(stringToWrite='======================================================\n')
+                writeToLog(stringToWrite='Log started at ')
+                writeToLog(stringToWrite=datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
+        if args.no_time:
+            no_time = 1
+            args.test = 1
+        if args.file_list == '-':
+            if verbosity:
+                print('Using stdin for file list')
+                if (args.log):
+                   writeToLog(stringToWrite='\nUsing stdin for file list') 
+            file_list = sys.stdin
+        elif args.file_list:
+            if verbosity:
+                print('Opening file list in', args.file_list)
+                if (args.log):
+                    writeToLog(stringToWrite='\nOpening file list in ')
+                    writeToLog(stringToWrite=args.file_list)
+            file_list = open(args.file_list)
+        else:
+            file_list = None
+        if args.exclude_list:
+            if verbosity:
+                print('Opening exclude list in', args.exclude_list)
+                if (args.log):
+                    writeToLog(stringToWrite='\nOpening exclude list in')
+                    writeToLog(stringToWrite=args.exclude_list)
+            exclude_list = [line.rstrip('\n').encode(FSENCODING) for line in open(args.exclude_list)]
+        else:
+            exclude_list = []
+
+        if (args.hashing_function):
+            #combined = '\t'.join(hashlib.algorithms_available)
+            #if (args.hashing_function in combined):
+
+            #word_to_check = args.hashing_function
+            #wordlist = hashlib.algorithms_available
+            #result = any(word_to_check in word for word in wordlist)
+
+            #algorithms_available = hashlib.algorithms_available
+            #search = args.hashing_function
+            #result = next((True for algorithms_available in algorithms_available if search in algorithms_available), False)
+            if (isValidHashingFunction(stringToValidate=args.hashing_function.upper()) == True):
+                hashing_function = args.hashing_function.upper()
+                if (verbosity):
+                    print('Using {} for hashing function'.format(args.hashing_function.upper()))   
+                    if (args.log):
+                       writeToLog(stringToWrite='\nUsing {} for hashing function'.format(args.hashing_function.upper()))
+            else:
+                if (verbosity):
+                    print("Invalid hashing function specified: {}. Using default {}".format(args.hashing_function,DEFAULT_HASH_FUNCTION))
+                    if (args.log):
+                        writeToLog(stringToWrite="\nInvalid hashing function specified: {}. Using default {}".format(args.hashing_function,DEFAULT_HASH_FUNCTION))
+                hashing_function = DEFAULT_HASH_FUNCTION
+        else:
+            hashing_function = DEFAULT_HASH_FUNCTION
+
         bt = Bitrot(
             verbosity=verbosity,
+            hashing_function=hashing_function,
             test=args.test,
+            email=args.email,
+            log = args.log,
+            no_time = args.no_time,
             follow_links=args.follow_links,
             commit_interval=args.commit_interval,
             chunk_size=args.chunk_size,
+            file_list=file_list,
+            exclude_list=exclude_list,
         )
         if args.fsencoding:
             FSENCODING = args.fsencoding
+
         try:
             bt.run()
         except BitrotException as bre:
-            print('error:', bre.args[1], file=sys.stderr)
+            print('Error:', bre.args[1], file=sys.stderr)
+            if (args.log):
+                writeToLog(stringToWrite='\nError: ')
+                writeToLog(stringToWrite=bre.args[1])
             sys.exit(bre.args[0])
 
+        if file_list:
+            file_list.close() # should be harmless if file_list == sys.stdin
 
 if __name__ == '__main__':
     run_from_command_line()


### PR DESCRIPTION
Added logging to file
Added grammar fixes
Added a time elapsed counter
Added email support for hash mismatch
Added option to ignore date modified (only checks hashes). Great for verifying backups for integrity (File Integrity Monitoring)
Added ability to specify hash function from command line. I found SHA512 to be just as fast as SHA1 on my machine
Total size now printed in B, KB, MB, GB, TB
Fixes for invalid characters in file names
Better warning printing
Integrates benshep's and liloman's latest changes