### PR TITLE
Pull 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ Change Log
 
 0.9.3
 ~~~~~
+* Added database vacuuming to shrink DB size on hard drive of old hashes that went missing
 * Added logging to file
 * Added grammar fixes
 * Added a time elapsed counter

--- a/README.rst
+++ b/README.rst
@@ -52,18 +52,19 @@ Change Log
 * Added logging to file
 * Added grammar fixes
 * Added a time elapsed counter
-* Added email support for hash mismatch
-* Added option to ignore date modified (only checks hashes). Great for verifying backups for integrity (File Integrity Monitoring)
-* Added ability to specify hash function from command line. I found SHA512 to be just as fast as SHA1 on my machine
+* Added email support for hash mismatch using -e or --email
+* Added option to ignore date modified (only checks hashes). Great for verifying backups for integrity (File Integrity Monitoring) using -t 2 or --test 2
+* Added ability to specify hash function from command line. I found SHA512 to be just as fast as SHA1 on my machine using -a or --hashing-function
 * Total size now printed in B, KB, MB, GB, TB
 * Fixes for invalid characters in file names
 * Better warning printing
 * Integrates benshep's and liloman's latest changes
 * Can now include and exclude at same time, and fixed logic. Exclude takes prescendence
-* Now prints out ignored files at the end with certain levels of verbosity
-* Added option to allow testing of only recent (default: last 1 day)of recently modified data (great for checking a backup you just synced for integruty)
+* Now prints out ignored files at the end with verbosity level 4
+* Added option to allow testing of only recent (default: last 1 day) of recently modified data (great for checking a backup you just synced for integruty) using -r or --recent
 * Fixed bug when file doesn't have a valid modification timestamp
-* Can now fix files that have invalid modification date, and rename files/dirs that have bad chars in name, using -f
+* Can now fix files that have invalid modification date, and rename files/dirs that have bad chars in name, using -f or --fix
+* Can now create MD5 or SFV files using -c or --sfv
 
 0.9.2
 ~~~~~

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,8 @@ Change Log
 * Can now include and exclude at same time, and fixed logic. Exclude takes prescendence
 * Now prints out ignored files at the end
 * Added option to allow testing of only last 3 days of recently modified data (great for checking a backup you just synced)
+* Fixed bug when file doesn't have a valid modification timestamp
+* Can now fix files that have invalid modification date, and rename files/dirs that have bad chars in name, using -f
 
 0.9.2
 ~~~~~

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,20 @@ performance improvements, I'm accepting pull requests! :)
 Change Log
 ----------
 
+0.9.3
+~~~~~
+* Added logging to file
+* Added grammar fixes
+* Added a time elapsed counter
+* Added email support for hash mismatch
+* Added option to ignore date modified (only checks hashes). Great for verifying backups for integrity (File Integrity Monitoring)
+* Added ability to specify hash function from command line. I found SHA512 to be just as fast as SHA1 on my machine
+* Total size now printed in B, KB, MB, GB, TB
+* Fixes for invalid characters in file names
+* Better warning printing
+* Integrates benshep's and liloman's latest changes
+* Can now include and exclude at same time, and fixed logic. Exclude takes prescendence
+
 0.9.2
 ~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -62,9 +62,9 @@ Change Log
 * Integrates benshep's and liloman's latest changes
 * Can now include and exclude at same time, and fixed logic. Exclude takes prescendence
 * Now prints out ignored files at the end with verbosity level 4
-* Added option to allow testing of only recent (default: last 1 day) of recently modified data (great for checking a backup you just synced for integruty) using -r or --recent
+* Added option to allow testing of only recent (default: last 1 day) of recently modified data (great for checking a backup you just synced for integrity) using -r or --recent
 * Fixed bug when file doesn't have a valid modification timestamp
-* Can now fix files that have invalid modification date, and rename files/dirs that have bad chars in name, using -f or --fix
+* Can now fix files that have invalid modification date, and rename files/dirs that have bad chars in name, using -f or --fix (dangerous)
 * Can now create MD5 or SFV files using -c or --sfv
 
 0.9.2

--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,8 @@ Change Log
 * Better warning printing
 * Integrates benshep's and liloman's latest changes
 * Can now include and exclude at same time, and fixed logic. Exclude takes prescendence
+* Now prints out ignored files at the end
+* Added option to allow testing of only last 3 days of recently modified data (great for checking a backup you just synced)
 
 0.9.2
 ~~~~~

--- a/README.rst
+++ b/README.rst
@@ -60,8 +60,8 @@ Change Log
 * Better warning printing
 * Integrates benshep's and liloman's latest changes
 * Can now include and exclude at same time, and fixed logic. Exclude takes prescendence
-* Now prints out ignored files at the end
-* Added option to allow testing of only last 3 days of recently modified data (great for checking a backup you just synced)
+* Now prints out ignored files at the end with certain levels of verbosity
+* Added option to allow testing of only recent (default: last 1 day)of recently modified data (great for checking a backup you just synced for integruty)
 * Fixed bug when file doesn't have a valid modification timestamp
 * Can now fix files that have invalid modification date, and rename files/dirs that have bad chars in name, using -f
 

--- a/README.rst
+++ b/README.rst
@@ -50,10 +50,10 @@ Change Log
 0.9.3
 ~~~~~
 * Added database vacuuming to shrink DB size on hard drive of old hashes that went missing
-* Added logging to file
+* Added logging to file using -g or ---log (on by default)
 * Added grammar fixes
 * Added a time elapsed counter
-* Added email support for hash mismatch using -e or --email
+* Added email support for hash mismatch using -e or --email (on by default)
 * Added option to ignore date modified (only checks hashes). Great for verifying backups for integrity (File Integrity Monitoring) using -t 2 or --test 2
 * Added ability to specify hash function from command line. I found SHA512 to be just as fast as SHA1 on my machine using -a or --hashing-function
 * Total size now printed in B, KB, MB, GB, TB

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -288,8 +288,6 @@ class Bitrot(object):
         renamed_paths = []
         errors = []
         emails = []
-        emails.append([])
-        emails.append([])
         tooOldList = []
         warnings = []
         current_size = 0
@@ -396,7 +394,8 @@ class Bitrot(object):
                 continue
             if stored_hash != new_hash:
                 errors.append(p)
-
+                emails.append([])
+                emails.append([])
                 emails[FIMErrorCounter].append(self.hashing_function)
                 emails[FIMErrorCounter].append(p.decode(FSENCODING))
                 emails[FIMErrorCounter].append(stored_hash)

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -67,7 +67,7 @@ def sendMail(stringToSend="", log=1, verbosity=1, subject=""):
     msg['From'] = email.utils.formataddr(('Author', 'recipient@gmail.com'))
     USERNAME = 'authorUsername'
     PASSWORD = 'authorPassword'
-
+    
     try:
         msg['Subject'] = subject
         # The actual mail send
@@ -582,7 +582,6 @@ class Bitrot(object):
 
         conn.commit()
 
-
         if self.verbosity:
             cur.execute('SELECT COUNT(path) FROM bitrot')
             all_count = cur.fetchone()[0]
@@ -603,8 +602,7 @@ class Bitrot(object):
                 fixedPropertiesCounter,
             )
 
-
-
+        cur.execute('vacuum')
         update_sha512_integrity(verbosity=self.verbosity, log=self.log)
 
         if self.verbosity:

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -189,6 +189,7 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=True, warnings = (),
                     #os.chdir(root)
                     #fullfilename=os.path.abspath(f)
                     #os.rename(f, cleanString(f))  # relative path, more elegant
+                    p_uniBackup = f
                     os.rename(os.path.join(root, f), os.path.join(root, cleanString(f)))
                     p_uni = cleanString(f)
                 except Exception as ex:
@@ -205,7 +206,7 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=True, warnings = (),
                 else:
                     fixedRenameList.append([])
                     fixedRenameList.append([])
-                    fixedRenameList[fixedRenameCounter].append(os.path.join(root, f))
+                    fixedRenameList[fixedRenameCounter].append(os.path.join(root, p_uniBackup))
                     fixedRenameList[fixedRenameCounter].append(os.path.join(root, cleanString(f)))
                     fixedRenameCounter += 1
 
@@ -215,6 +216,7 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=True, warnings = (),
                     # chdir before renaming
                     #os.chdir(root)
                     #fullfilename=os.path.abspath(d)
+                    p_uniBackup = d
                     os.rename(os.path.join(root, d), os.path.join(root, cleanString(d)))
                     #os.rename(d, cleanString(d))  # relative path, more elegant
                     p_uni = cleanString(d)
@@ -232,7 +234,7 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=True, warnings = (),
                 else:
                     fixedRenameList.append([])
                     fixedRenameList.append([])
-                    fixedRenameList[fixedRenameCounter].append(os.path.join(root, d))
+                    fixedRenameList[fixedRenameCounter].append(os.path.join(root, p_uniBackup))
                     fixedRenameList[fixedRenameCounter].append(os.path.join(root, cleanString(d)))
                     fixedRenameCounter += 1
     return fixedRenameList, fixedRenameCounter

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -836,9 +836,9 @@ class Bitrot(object):
                         writeToLog(stringToWrite='  Added missing modification time to {}'.format(fixedPropertiesList[i][0]))
             
                         
-        if any((new_paths, updated_paths, missing_paths, renamed_paths, ignoredList, tooOldList)):
-            if (self.log):
-                writeToLog(stringToWrite='\n')
+        #if any((new_paths, updated_paths, missing_paths, renamed_paths, ignoredList, tooOldList)):
+        #    if (self.log):
+        #        writeToLog(stringToWrite='\n')
 
         if self.test and self.verbosity:
             print('\nDatabase file not updated on disk (test mode).')

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -195,12 +195,12 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=True, warnings = (),
                     warnings.append(f)
                     print(
                         '\rCan\'t rename: {} due to warning: `{}`'.format(
-                            f,ex,
+                            os.path.join(root, f),ex,
                         ),
                         file=sys.stderr,
                     )
                     if (log):
-                        writeToLog(stringToWrite='\rCan\'t rename: {} due to warning: `{}`'.format(f,ex))
+                        writeToLog(stringToWrite='\rCan\'t rename: {} due to warning: `{}`'.format(os.path.join(root, f),ex))
                     continue
                 else:
                     fixedRenameList.append([])
@@ -222,12 +222,12 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=True, warnings = (),
                     warnings.append(d)
                     print(
                         '\rCan\'t rename: {} due to warning: `{}`'.format(
-                            d,ex,
+                            os.path.join(root, d),ex,
                         ),
                         file=sys.stderr,
                     )
                     if (log):
-                        writeToLog(stringToWrite='\rCan\'t rename: {} due to warning: `{}`'.format(d,ex))
+                        writeToLog(stringToWrite='\rCan\'t rename: {} due to warning: `{}`'.format(os.path.join(root, d),ex))
                     continue
                 else:
                     fixedRenameList.append([])
@@ -693,7 +693,7 @@ class Bitrot(object):
                 if (self.log):
                     writeToLog(stringToWrite='\n{} entries in the database.'.format(all_count))
 
-        if self.verbosity >= 3:
+        if self.verbosity >= 4:
             if (ignoredList):
                 if (len(ignoredList) == 1):
                     print("\n1 files excluded: ")
@@ -730,7 +730,7 @@ class Bitrot(object):
                             if (self.log):
                                 writeToLog("  \n{}".format(row))
 
-        if self.verbosity >= 2:
+        if self.verbosity >= 3:
             if new_paths:
                 if (len(new_paths) == 1):
                     print('\n1 new entry:')
@@ -786,6 +786,7 @@ class Bitrot(object):
                     if (self.log):
                         writeToLog(stringToWrite='\n from {} to {}'.format(path[0],path[1]))
                     
+        if self.verbosity >= 2:
             if missing_paths:
                 if (len(missing_paths) == 1):
                     print('\n1 entry missing:')
@@ -833,9 +834,9 @@ class Bitrot(object):
                         writeToLog(stringToWrite='  Added missing modification time to {}'.format(fixedPropertiesList[i][0]))
             
                         
-        #if any((new_paths, updated_paths, missing_paths, renamed_paths, ignoredList, tooOldList)):
-        #    if (self.log):
-        #        writeToLog(stringToWrite='\n')
+        if any((new_paths, updated_paths, missing_paths, renamed_paths, ignoredList, tooOldList)):
+            if (self.log):
+                writeToLog(stringToWrite='\n')
 
         if self.test and self.verbosity:
             print('\nDatabase file not updated on disk (test mode).')
@@ -1148,8 +1149,9 @@ def run_from_command_line():
         '-v', '--verbose', default=1,
         help='Level 0: Don\'t print anything besides checksum errors.\n'
         'Level 1: Normal amount of verbosity.\n'
-        'Level 2: List new, updated and missing entries.\n'
-        'Level 3: List new, updated and missing entries, and ignored files.\n')
+        'Level 2: List missing, and fixed entries.\n'
+        'Level 3: List missing, fixed, new, renamed, and updated entries.\n'
+        'Level 4: List missing, fixed, new, renamed, and updated entries, and ignored files.\n')
     parser.add_argument(
         '-e', '--email', action='store_true',
         help='email file integirty errors')
@@ -1180,7 +1182,7 @@ def run_from_command_line():
                      writeToLog("\nInvalid test option selected: {}. Using default level 1.".format(args.verbose))
                 verbosity = 1
                 pass
-            if (verbosity != 0 and verbosity != 1 and verbosity != 2 and verbosity != 3):
+            if (verbosity != 0 and verbosity != 1 and verbosity != 2 and verbosity != 3 and verbosity != 4):
                 print("Invalid verbosity option selected: {}. Using default level 1.".format(args.verbose))
                 if (args.log):
                      writeToLog("\nInvalid test option selected: {}. Using default level 1.".format(args.verbose))

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -691,15 +691,6 @@ class Bitrot(object):
             if (self.log):
                 writeToLog(' {} warnings found.'.format(warning_count))
 
-
-        # help='Level 0: Don\'t print anything besides checksum errors.\n'
-        # 'Level 1: Normal amount of verbosity.\n'
-        # 'Level 2: List missing, and fixed entries.\n'
-        # 'Level 3: List missing, fixed, new, renamed, and updated entries.\n'
-        # 'Level 4: List missing, fixed, new, renamed, and updated entries, and ignored files.\n')
-
-
-
         if self.verbosity >= 1:
             if (all_count == 1):
                 print(

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -60,12 +60,12 @@ if sys.version[0] == '2':
 def sendMail(stringToSend="", log=1, verbosity=1, subject=""):
     msg = MIMEText(stringToSend)
 
-    FROMADDR = 'author@gmail.com'
-    TOADDR  = 'recipient@gmail.com'
-    msg['To'] = email.utils.formataddr(('Recipient', 'recipient@gmail.com'))
-    msg['From'] = email.utils.formataddr(('Author', 'recipient@gmail.com'))
-    USERNAME = 'authorUsername'
-    PASSWORD = 'authorPassword'
+    DEFAULT_CHUNK_SIZE = 16384  # block size in HFS+; 4X the block size in ext4
+    DOT_THRESHOLD = 2
+    VERSION = (0, 9, 3)
+    IGNORED_FILE_SYSTEM_ERRORS = {errno.ENOENT, errno.EACCES}
+    FSENCODING = sys.getfilesystemencoding()
+    DEFAULT_HASH_FUNCTION = "SHA512" 
 
     try:
         msg['Subject'] = subject
@@ -602,7 +602,9 @@ class Bitrot(object):
                 fixedPropertiesCounter,
             )
 
-        cur.execute('vacuum')
+        if not self.test:
+            cur.execute('vacuum')
+
         update_sha512_integrity(verbosity=self.verbosity, log=self.log)
 
         if self.verbosity:

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -606,6 +606,7 @@ class Bitrot(object):
                             if (self.log):
                                 writeToLog("  \n{}".format(row))
 
+        if self.verbosity >= 2:
             if new_paths:
                 if (len(new_paths) == 1):
                     print('\n1 new entry:')
@@ -677,12 +678,14 @@ class Bitrot(object):
                     if (self.log):
                         writeToLog(stringToWrite='\n {}'.format(path))
                         
-            if not any((new_paths, updated_paths, missing_paths, renamed_paths)):
-                print()
+        if any((new_paths, updated_paths, missing_paths, renamed_paths, ignoredList, tooOldList)):
+            if (self.log):
+                writeToLog(stringToWrite='\n')
+
         if self.test and self.verbosity:
             print('\nDatabase file not updated on disk (test mode).')
             if (self.log):
-                writeToLog(stringToWrite='\n\nDatabase file not updated on disk (test mode).')
+                writeToLog(stringToWrite='\nDatabase file not updated on disk (test mode).')
 
     def handle_unknown_path(self, cur, new_path, new_mtime, new_sha1):
         """Either add a new entry to the database or update the existing entry

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -38,40 +38,111 @@ import stat
 import sys
 import tempfile
 import time
-
+import smtplib
+from fnmatch import fnmatch
+import email.utils
+from email.mime.text import MIMEText
+from datetime import timedelta
+import binascii
+#import re
 
 DEFAULT_CHUNK_SIZE = 16384  # block size in HFS+; 4X the block size in ext4
-DOT_THRESHOLD = 200
-VERSION = (0, 9, 2)
+DOT_THRESHOLD = 2
+VERSION = (0, 9, 3)
 IGNORED_FILE_SYSTEM_ERRORS = {errno.ENOENT, errno.EACCES}
 FSENCODING = sys.getfilesystemencoding()
-
+DEFAULT_HASH_FUNCTION = "SHA512"
 
 if sys.version[0] == '2':
     str = type(u'text')
     # use `bytes` for bytestrings
 
+def sendMail(stringToSend="", log=1, verbosity=1, subject=""):
+    msg = MIMEText(stringToSend)
 
-def sha1(path, chunk_size):
-    digest = hashlib.sha1()
-    with open(path, 'rb') as f:
-        d = f.read(chunk_size)
-        while d:
-            digest.update(d)
-            d = f.read(chunk_size)
-    return digest.hexdigest()
+    FROMADDR = 'author@gmail.com'
+    TOADDR  = 'recipient@gmail.com'
+    msg['To'] = email.utils.formataddr(('Recipient', 'recipient@gmail.com'))
+    msg['From'] = email.utils.formataddr(('Author', 'recipient@gmail.com'))
+    USERNAME = 'authorUsername'
+    PASSWORD = 'authorPassword'
+    
+    try:
+        msg['Subject'] = subject
+        # The actual mail send
+        server = smtplib.SMTP('smtp.gmail.com:587')
+        server.starttls()
+        server.login(USERNAME,PASSWORD)
+        server.sendmail(FROMADDR, TOADDR, msg.as_string())
+        server.quit()
+    except Exception as err:
+        print('Email sending error:', err)
+        if (log):
+            writeToLog(stringToWrite='\n\nEmail sending error: {}'.format(err))
 
+def isValidHashingFunction(stringToValidate=""):
+    if  (stringToValidate == "SHA1"
+      or stringToValidate == "SHA224"
+      or stringToValidate == "SHA384"
+      or stringToValidate == "SHA256"
+      or stringToValidate == "SHA512"
+      or stringToValidate == "MD5"):
+        return True
+    else:
+        return False
+
+def calculateUnits(total_size = 0):
+        if (total_size/1024/1024/1024/1024/1024/1024/1024/1024 >= 1):
+            sizeUnits = "YB"
+            total_size = total_size/1024/1024/1024/1024/1024/1024/1024/1024
+        elif (total_size/1024/1024/1024/1024/1024/1024/1024 >= 1):
+            sizeUnits = "ZB"
+            total_size = total_size/1024/1024/1024/1024/1024/1024/1024
+        elif (total_size/1024/1024/1024/1024/1024/1024 >= 1):
+            sizeUnits = "EB"
+            total_size = total_size/1024/1024/1024/1024/1024/1024
+        elif (total_size/1024/1024/1024/1024/1024 >= 1):
+            sizeUnits = "PB"
+            total_size = total_size/1024/1024/1024/1024/1024
+        elif (total_size/1024/1024/1024/1024 >= 1):
+            sizeUnits = "TB"
+            total_size = total_size/1024/1024/1024/1024
+        elif (total_size/1024/1024/1024 >= 1):
+            sizeUnits = "GB"
+            total_size = total_size/1024/1024/1024
+        elif (total_size/1024/1024 >= 1):
+            sizeUnits = "MB"
+            total_size = total_size/1024/1024
+        elif (total_size/1024 >= 1):
+            sizeUnits = "KB"
+            total_size = total_size/1024
+        else:
+            sizeUnits = "B"
+            total_size = total_size
+        return sizeUnits, total_size
+
+def CRC32_from_file(filename):
+    buf = open(filename,'rb').read()
+    buf = (binascii.crc32(buf) & 0xFFFFFFFF)
+    return "%08X" % buf
+
+def cleanString(stringToClean=""):
+    #stringToClean=re.sub(r'[\\/*?:"<>|]',"",stringToClean)
+    stringToClean = ''.join([x for x in stringToClean if ord(x) < 128])
+    return stringToClean
 
 def ts():
     return datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S%z')
-
 
 def get_sqlite3_cursor(path, copy=False):
     path = path.decode(FSENCODING)
     if copy:
         if not os.path.exists(path):
-            raise ValueError("error: bitrot database at {} does not exist."
+            raise ValueError("Error: bitrot database at {} does not exist."
                              "".format(path))
+            if (self.log):
+                writeToLog(stringToWrite="\nError: bitrot database at {} does not exist."
+                    "".format(path))
         db_copy = tempfile.NamedTemporaryFile(prefix='bitrot_', suffix='.db',
                                               delete=False)
         with open(path, 'rb') as db_orig:
@@ -93,8 +164,8 @@ def get_sqlite3_cursor(path, copy=False):
     atexit.register(conn.commit)
     return conn
 
-
-def list_existing_paths(directory, expected=(), ignored=(), follow_links=False):
+def list_existing_paths(directory, expected=(), ignored=(), included=(), 
+                        verbosity=1, follow_links=False, log=1):
     """list_existing_paths('/dir') -> ([path1, path2, ...], total_size)
 
     Returns a tuple with a list with existing files in `directory` and their
@@ -104,7 +175,7 @@ def list_existing_paths(directory, expected=(), ignored=(), follow_links=False):
     `follow_links` is False (the default).  All entries present in `expected`
     must be files (can't be directories or symlinks).
     """
-    paths = set()
+    paths = []
     total_size = 0
     for path, _, files in os.walk(directory):
         for f in files:
@@ -113,9 +184,12 @@ def list_existing_paths(directory, expected=(), ignored=(), follow_links=False):
                 p_uni = p.decode(FSENCODING)
             except UnicodeDecodeError:
                 binary_stderr = getattr(sys.stderr, 'buffer', sys.stderr)
-                binary_stderr.write(b"warning: cannot decode file name: ")
+                warnings.append(p)
+                binary_stderr.write(b"\rWarning: cannot decode file name: ")
                 binary_stderr.write(p)
                 binary_stderr.write(b"\n")
+                if (log):
+                    writeToLog(stringToWrite="\nWarning: cannot decode file name: {}".format(p))
                 continue
 
             try:
@@ -127,12 +201,44 @@ def list_existing_paths(directory, expected=(), ignored=(), follow_links=False):
                 if ex.errno not in IGNORED_FILE_SYSTEM_ERRORS:
                     raise
             else:
-                if not stat.S_ISREG(st.st_mode) or p in ignored:
-                    continue
-                paths.add(p)
-                total_size += st.st_size
-    return paths, total_size
+                # split path /dir1/dir2/file.txt into
+                # ['dir1', 'dir2', 'file.txt']
+                # and match on any of these components
+                # so we could use 'dir*', '*2', '*.txt', etc. to exclude anything
+                exclude_this = [fnmatch(file.encode(FSENCODING), wildcard) 
+                                for file in p.decode(FSENCODING).split(os.path.sep)
+                                for wildcard in ignored]
+                include_this = [fnmatch(file.encode(FSENCODING), wildcard) 
+                                for file in p.decode(FSENCODING).split(os.path.sep)
+                                for wildcard in included]                
+              #  if included:
+              #      if  any(include_this) or any([fnmatch(p, exc) for exc in included]):
+              #          print("Found good shit: {}".format(p.decode(FSENCODING)))
+              #      else:
+              #          if verbosity > 2:
+              #              #print('Ignoring file: {}'.format(p))
+              #             print('Ignoring file: {}'.format(p.decode(FSENCODING)))
+              #             if (log):
+              #                  #writeToLog(stringToWrite="\nIgnoring file: {}".format(p))
+              #                  writeToLog(stringToWrite="\nIgnoring file: {}".format(p.decode(FSENCODING)))
+              #          continue
+              #  if ((included) and (not any([fnmatch(p, exc) for exc in included]) or not any(include_this))):
+              #      print("Found bad shit: {}".format(p.decode(FSENCODING)))
+              #      return
 
+                if not stat.S_ISREG(st.st_mode) or any(exclude_this) or any([fnmatch(p, exc) for exc in ignored]) or (included and not any([fnmatch(p, exc) for exc in included]) and not any(include_this)):
+                #if not stat.S_ISREG(st.st_mode) or any([fnmatch(p, exc) for exc in ignored]):
+                    if verbosity > 2:
+                        #print('Ignoring file: {}'.format(p))
+                        print('Ignoring file: {}'.format(p.decode(FSENCODING)))
+                        if (log):
+                            #writeToLog(stringToWrite="\nIgnoring file: {}".format(p))
+                            writeToLog(stringToWrite="\nIgnoring file: {}".format(p.decode(FSENCODING)))
+                    continue
+                paths.append(p)
+                total_size += st.st_size
+    paths.sort()
+    return paths, total_size
 
 class BitrotException(Exception):
     pass
@@ -140,16 +246,24 @@ class BitrotException(Exception):
 
 class Bitrot(object):
     def __init__(
-        self, verbosity=1, test=False, follow_links=False, commit_interval=300,
-        chunk_size=DEFAULT_CHUNK_SIZE,
+        self, verbosity=1, email = False, log = False, test=False, follow_links=False, commit_interval=300,
+        chunk_size=DEFAULT_CHUNK_SIZE, include_list=[], exclude_list=[],  no_time=False, hashing_function="", sfv="MD5"
     ):
         self.verbosity = verbosity
         self.test = test
         self.follow_links = follow_links
         self.commit_interval = commit_interval
         self.chunk_size = chunk_size
+        self.include_list = include_list
+        self.exclude_list = exclude_list
         self._last_reported_size = ''
         self._last_commit_ts = 0
+        self.email = email
+        self.log = log
+        self.no_time = no_time
+        self.startTime = time.clock()
+        self.hashing_function = hashing_function
+        self.sfv = sfv
 
     def maybe_commit(self, conn):
         if time.time() < self._last_commit_ts + self.commit_interval:
@@ -160,10 +274,18 @@ class Bitrot(object):
         self._last_commit_ts = time.time()
 
     def run(self):
-        check_sha512_integrity(verbosity=self.verbosity)
+        check_sha512_integrity(verbosity=self.verbosity, log=self.log)
 
-        bitrot_db = get_path()
         bitrot_sha512 = get_path(ext=b'sha512')
+        bitrot_log = get_path(ext=b'log')
+        bitrot_db = get_path()
+        bitrot_sfv = None
+        bitrot_sfv = get_path(ext=b'sfv')
+        bitrot_md5 = get_path(ext=b'md5')
+        #bitrot_db = os.path.basename(get_path())
+        #bitrot_sha512 = os.path.basename(get_path(ext=b'sha512'))
+        #bitrot_log = os.path.basename(get_path(ext=b'log'))
+     
         try:
             conn = get_sqlite3_cursor(bitrot_db, copy=self.test)
         except ValueError:
@@ -171,21 +293,34 @@ class Bitrot(object):
                 2,
                 'No database exists so cannot test. Run the tool once first.',
             )
+            if (self.log):
+                writeToLog(stringToWrite="\nNo database exists so cannot test. Run the tool once first.")
 
         cur = conn.cursor()
         new_paths = []
         updated_paths = []
         renamed_paths = []
         errors = []
+        emails = []
+        warnings = []
         current_size = 0
         missing_paths = self.select_all_paths(cur)
-        hashes = self.select_all_hashes(cur)
+        #if self.include_list:
+        #    paths = [line.rstrip('\n').encode(FSENCODING)
+        #        for line in self.include_list.readlines()]
+        #    total_size = sum([os.path.getsize(filename) for filename in paths])
+        #else:
         paths, total_size = list_existing_paths(
-            b'.', expected=missing_paths, ignored={bitrot_db, bitrot_sha512},
+            b'.', expected=missing_paths, 
+            ignored=[bitrot_db, bitrot_sha512,bitrot_log,bitrot_sfv,bitrot_md5] + self.exclude_list,
+            included=self.include_list,
             follow_links=self.follow_links,
+            verbosity=self.verbosity,
+            log=self.log
         )
 
-        for p in sorted(paths):
+        FIMErrorCounter = 0;
+        for p in paths:
             p_uni = p.decode(FSENCODING)
             try:
                 st = os.stat(p)
@@ -194,13 +329,18 @@ class Bitrot(object):
                     # The file disappeared between listing existing paths and
                     # this run or is (temporarily?) locked with different
                     # permissions. We'll just skip it for now.
+                    warnings.append(p)
                     print(
-                        '\rwarning: `{}` is currently unavailable for '
+                        '\rWarning: `{}` is currently unavailable for '
                         'reading: {}'.format(
-                            p_uni, ex,
+                            #p_uni, ex,
+                            p.decode(FSENCODING), ex,
                         ),
                         file=sys.stderr,
                     )
+                    if (self.log):
+                        #writeToLog(stringToWrite='\nWarning: `{}` is currently unavailable for reading: {}'.format(p_uni, ex))
+                        writeToLog(stringToWrite='\nWarning: `{}` is currently unavailable for reading: {}'.format(p.decode(FSENCODING), ex))
                     continue
 
                 raise   # Not expected? https://github.com/ambv/bitrot/issues/
@@ -208,18 +348,24 @@ class Bitrot(object):
             new_mtime = int(st.st_mtime)
             current_size += st.st_size
             if self.verbosity:
-                self.report_progress(current_size, total_size)
+                self.report_progress(current_size, total_size, p_uni)
 
             missing_paths.discard(p_uni)
             try:
-                new_sha1 = sha1(p, self.chunk_size)
+                new_hash = hash(p, self.chunk_size,self.hashing_function,log=self.log,sfv=self.sfv)
             except (IOError, OSError) as e:
+                warnings.append(p)
                 print(
-                    '\rwarning: cannot compute hash of {} [{}]'.format(
-                        p, errno.errorcode[e.args[0]],
+                    '\rWarning: cannot compute hash of {} [{}]'.format(
+                        #p, errno.errorcode[e.args[0]],
+                        p.decode(FSENCODING),errno.errorcode[e.args[0]],
                     ),
                     file=sys.stderr,
                 )
+                if (self.log):
+                    writeToLog(stringToWrite='\n\nWarning: cannot compute hash of {} [{}]'.format(
+                            #p, errno.errorcode[e.args[0]]))
+                            p.decode(FSENCODING), errno.errorcode[e.args[0]]))
                 continue
 
             cur.execute('SELECT mtime, hash, timestamp FROM bitrot WHERE '
@@ -227,35 +373,57 @@ class Bitrot(object):
             row = cur.fetchone()
             if not row:
                 stored_path = self.handle_unknown_path(
-                    cur, p_uni, new_mtime, new_sha1, paths, hashes
+                    cur, p_uni, new_mtime, new_hash
                 )
                 self.maybe_commit(conn)
 
                 if p_uni == stored_path:
-                    new_paths.append(p)   # FIXME: shouldn't that be p_uni?
+                    new_paths.append(p)   # FIXME: shouldn't that be p_uni instead of p?
                 else:
                     renamed_paths.append((stored_path, p_uni))
                     missing_paths.discard(stored_path)
                 continue
-
-            stored_mtime, stored_sha1, stored_ts = row
-            if int(stored_mtime) != new_mtime:
+            stored_mtime, stored_hash, stored_ts = row
+            if (int(stored_mtime) != new_mtime) and (self.no_time == False):
                 updated_paths.append(p)
                 cur.execute('UPDATE bitrot SET mtime=?, hash=?, timestamp=? '
                             'WHERE path=?',
-                            (new_mtime, new_sha1, ts(), p_uni))
+                            (new_mtime, new_hash, ts(), p_uni))
                 self.maybe_commit(conn)
                 continue
-
-            if stored_sha1 != new_sha1:
+            if stored_hash != new_hash:
                 errors.append(p)
+                
+                emails.append([])
+                emails.append([])
+                emails[FIMErrorCounter].append(self.hashing_function)
+                emails[FIMErrorCounter].append(p.decode(FSENCODING))
+                emails[FIMErrorCounter].append(stored_hash)
+                emails[FIMErrorCounter].append(new_hash)
+                emails[FIMErrorCounter].append(stored_ts)
+
                 print(
-                    '\rerror: SHA1 mismatch for {}: expected {}, got {}.'
-                    ' Last good hash checked on {}.'.format(
-                        p, stored_sha1, new_sha1, stored_ts
+                    '\rError: {} mismatch for {}\nExpected: {}\nGot:      {}'
+                    '\nLast good hash checked on {}\n'.format(
+                    #p, stored_hash, new_hash, stored_ts
+                    self.hashing_function,p.decode(FSENCODING), stored_hash, new_hash, stored_ts
                     ),
                     file=sys.stderr,
                 )
+                if (self.log):
+                    writeToLog(stringToWrite=
+                        '\n\nError: {} mismatch for {}\nExpected: {}\nGot:          {}'
+                        '\nLast good hash checked on {}'.format(
+                        #p, stored_hash, new_hash, stored_ts
+                        self.hashing_function,p.decode(FSENCODING), stored_hash, new_hash, stored_ts))   
+                FIMErrorCounter += 1    
+
+        if (self.email):
+            if (FIMErrorCounter >= 1):
+                emailToSendString=""
+                for i in range(0, FIMErrorCounter):
+                    emailToSendString +="Error {} mismatch for {} \nExpected {}\nGot:          {}\nLast good hash checked on {}\n\n".format(emails[i][0],emails[i][1],emails[i][2],emails[i][3],emails[i][4])
+                sendMail(emailToSendString,log=self.log,verbosity=self.verbosity, subject="FIM Error")
 
         for path in missing_paths:
             cur.execute('DELETE FROM bitrot WHERE path=?', (path,))
@@ -269,18 +437,37 @@ class Bitrot(object):
                 total_size,
                 all_count,
                 len(errors),
+                len(warnings),
                 new_paths,
                 updated_paths,
                 renamed_paths,
                 missing_paths,
             )
 
-        update_sha512_integrity(verbosity=self.verbosity)
+        update_sha512_integrity(verbosity=self.verbosity, log=self.log)
+
+        if self.verbosity:
+            recordTimeElapsed(startTime = self.startTime, log = self.log)
+
+        if warnings:
+            if len(warnings) == 1:
+                print('Warning: There was 1 warning found.')
+                if (self.log):
+                    writeToLog(stringToWrite='\nWarning: There was 1 warning found.')
+            else:
+                print('Warning: There were {} warnings found.'.format(len(warnings)))
+                if (self.log):
+                    writeToLog(stringToWrite='\nWarning: There were {} warnings found.'.format(len(warnings)))
 
         if errors:
-            raise BitrotException(
-                1, 'There were {} errors found.'.format(len(errors)), errors,
-            )
+            if len(errors) == 1:
+                raise BitrotException(
+                    1, 'There was 1 error found.',
+                )
+            else:
+                raise BitrotException(
+                    1, 'There were {} errors found.'.format(len(errors)), errors,
+                )
 
     def select_all_paths(self, cur):
         result = set()
@@ -291,96 +478,202 @@ class Bitrot(object):
             row = cur.fetchone()
         return result
 
-    def select_all_hashes(self, cur):
-        result = {}
-        cur.execute('SELECT hash, path FROM bitrot')
-        row = cur.fetchone()
-        while row: 
-            rhash, rpath = row
-            result.setdefault(rhash, set()).add(rpath)
-            row = cur.fetchone()
-        return result
-
-    def report_progress(self, current_size, total_size):
+    def report_progress(self, current_size, total_size, current_path):
         size_fmt = '\r{:>6.1%}'.format(current_size/(total_size or 1))
         if size_fmt == self._last_reported_size:
             return
 
-        sys.stdout.write(size_fmt)
+        # show current file in progress too
+        terminal_size = shutil.get_terminal_size()
+        # but is it too big for terminal window?
+        cols = terminal_size.columns
+        max_path_size = cols - len(size_fmt) - 1
+
+        #without this line, weird character in the filename could cause strange printing output
+        current_path = cleanString(stringToClean=current_path)
+
+        if len(current_path) > max_path_size:
+            # show first half and last half, separated by ellipsis
+            # e.g. averylongpathnameaveryl...ameaverylongpathname
+            half_mps = (max_path_size - 3) // 2
+            current_path = current_path[:half_mps] + '...' + current_path[-half_mps:]
+        else:
+            # pad out with spaces, otherwise previous filenames won't be erased
+            current_path += ' ' * (max_path_size - len(current_path))
+            
+        sys.stdout.write(size_fmt + ' ' + current_path)
         sys.stdout.flush()
         self._last_reported_size = size_fmt
 
+
     def report_done(
-        self, total_size, all_count, error_count, new_paths, updated_paths,
+        self, total_size, all_count, error_count, warning_count, new_paths, updated_paths,
         renamed_paths, missing_paths):
-        print('\rFinished. {:.2f} MiB of data read. {} errors found.'
-            ''.format(total_size/1024/1024, error_count))
+
+        sizeUnits , total_size = calculateUnits(total_size=total_size)
+
+        if (error_count == 1):
+                print('\rFinished. {:.2f} {} of data read. 1 error found. '.format(total_size,sizeUnits),end="")
+                if (self.log):
+                    writeToLog(stringToWrite='\n\nFinished. {:.2f} {} of data read. '.format(total_size,sizeUnits))
+        else:
+            print('\rFinished. {:.2f} {} of data read. {} errors found. '.format(total_size, sizeUnits, error_count),end="")
+            if (self.log):
+                writeToLog(stringToWrite='\n\nFinished. {:.2f} MiB of data read. {} errors found. '.format(total_size, error_count, sizeUnits))
+
+        if (warning_count == 1):
+            print('1 warning found.')
+            if (self.log):
+                writeToLog(stringToWrite='1 warning found')
+        else:
+            print('{} warnings found.'.format(warning_count))
+            if (self.log):
+                writeToLog(stringToWrite='{} warnings found.'.format(warning_count))
+
         if self.verbosity == 1:
-            print(
+            if (all_count == 1):
+                print(
+                    '1 entry in the database, {} new, {} updated, '
+                    '{} renamed, {} missing.'.format(
+                        len(new_paths), len(updated_paths),
+                        len(renamed_paths), len(missing_paths)))
+                if (self.log):
+                    writeToLog(stringToWrite=
+                    '\n1 entry in the database, {} new, {} updated, '
+                    '{} renamed, {} missing.'.format(
+                        len(new_paths), len(updated_paths),
+                        len(renamed_paths), len(missing_paths)))
+            else:
+                print(
                 '{} entries in the database, {} new, {} updated, '
                 '{} renamed, {} missing.'.format(
                     all_count, len(new_paths), len(updated_paths),
-                    len(renamed_paths), len(missing_paths),
-                ),
-            )
+                    len(renamed_paths), len(missing_paths)))
+                if (self.log):
+                    writeToLog(stringToWrite=
+                    '\n{} entries in the database, {} new, {} updated, '
+                    '{} renamed, {} missing.'.format(
+                        all_count, len(new_paths), len(updated_paths),
+                        len(renamed_paths), len(missing_paths)))
+
         elif self.verbosity > 1:
-            print('{} entries in the database.'.format(all_count), end=' ')
+            if (all_count == 1):
+                print('1 entry in the database.')
+                if (self.log):
+                    writeToLog(stringToWrite='1 entry in the database.')
+            else:
+                print('{} entries in the database.'.format(all_count), end=' ')
+                if (self.log):
+                    writeToLog(stringToWrite='\n{} entries in the database.'.format(all_count))
+
             if new_paths:
-                print('{} entries new:'.format(len(new_paths)))
+                if (len(new_paths) == 1):
+                    print('\n1 new entry:')
+                    if (self.log):
+                        writeToLog(stringToWrite='\n1 new entry:')
+                else:
+                    print('\n{} new entries:'.format(len(new_paths)))
+                    if (self.log):
+                        writeToLog(stringToWrite='\n{} new entries:'.format(len(new_paths)))
+
                 new_paths.sort()
                 for path in new_paths:
                     print(' ', path.decode(FSENCODING))
+                    if (self.log):
+                        writeToLog(stringToWrite='\n {}'.format(path.decode(FSENCODING)))
+
             if updated_paths:
-                print('{} entries updated:'.format(len(updated_paths)))
+                if (len(updated_paths) == 1):
+                    print('\n1 entry updated:')
+                    if (self.log):
+                        writeToLog(stringToWrite='\n1 entry updated:')
+                else:
+                    print('\n{} entries updated:'.format(len(updated_paths)))
+                    if (self.log):
+                        writeToLog(stringToWrite='\n{} entries updated:'.format(len(updated_paths)))
+
                 updated_paths.sort()
                 for path in updated_paths:
                     print(' ', path.decode(FSENCODING))
+                    if (self.log):
+                        writeToLog(stringToWrite='\n {}'.format(path.decode(FSENCODING)))
+
             if renamed_paths:
-                print('{} entries renamed:'.format(len(renamed_paths)))
+                if (len(renamed_paths) == 1):
+                    print('\n1 entry renamed:')
+                    if (self.log):
+                        writeToLog(stringToWrite='\n1 entry renamed:')
+                else:
+                    print('\n{} entries renamed:'.format(len(renamed_paths)))
+                    if (self.log):
+                        writeToLog(stringToWrite='\n{} entries renamed:'.format(len(renamed_paths)))
+
                 renamed_paths.sort()
                 for path in renamed_paths:
                     print(
-                        ' from',
-                        path[0].decode(FSENCODING),
+                        '  from',
+                        #path[0].decode(FSENCODING),
+                        path[0],
                         'to',
-                        path[1].decode(FSENCODING),
+                        #path[1].decode(FSENCODING),
+                        path[1],
                     )
+                    if (self.log):
+                        writeToLog(stringToWrite='\n from {} to {}'.format(path[0],path[1]))
+                    
             if missing_paths:
-                print('{} entries missing:'.format(len(missing_paths)))
+                if (len(missing_paths) == 1):
+                    print('\n1 entry missing:')
+                    if (self.log):
+                        writeToLog(stringToWrite='\n1 entry missing:')
+                else:
+                    print('\n{} entries missing:'.format(len(missing_paths)))
+                    if (self.log):
+                        writeToLog(stringToWrite='\n{} entries missing:'.format(len(missing_paths)))
+
                 missing_paths = sorted(missing_paths)
                 for path in missing_paths:
                     print(' ', path)
-            if not any((new_paths, updated_paths, missing_paths)):
+                    if (self.log):
+                        writeToLog(stringToWrite='\n {}'.format(path))
+                        
+            if not any((new_paths, updated_paths, missing_paths, renamed_paths)):
                 print()
         if self.test and self.verbosity:
-            print('warning: database file not updated on disk (test mode).')
+            print('Database file not updated on disk (test mode).')
+            if (self.log):
+                writeToLog(stringToWrite='\nDatabase file not updated on disk (test mode).')
 
-    def handle_unknown_path(self, cur, new_path, new_mtime, new_sha1, paths, hashes):
+    def handle_unknown_path(self, cur, new_path, new_mtime, new_sha1):
         """Either add a new entry to the database or update the existing entry
         on rename.
 
         Returns `new_path` if the entry was indeed new or the `stored_path` (e.g.
         outdated path) if there was a rename.
         """
+        cur.execute('SELECT mtime, path, timestamp FROM bitrot WHERE hash=?',
+                    (new_sha1,))
+        rows = cur.fetchall()
+        for row in rows:
+            stored_mtime, stored_path, stored_ts = row
+            if os.path.exists(stored_path):
+                # file still exists, move on
+                continue
 
-        try: # if the path isn't in the database
-            found = [path for path in hashes[new_sha1] if path not in paths]
-            renamed = found.pop()
             # update the path in the database
             cur.execute(
                 'UPDATE bitrot SET mtime=?, path=?, timestamp=? WHERE path=?',
-                (new_mtime, new_path, ts(), renamed),
+                (new_mtime, new_path, ts(), stored_path),
             )
 
-            return renamed
-        
-        # From hashes[new_sha1] or found.pop() 
-        except (KeyError,IndexError):
-            cur.execute(
-                'INSERT INTO bitrot VALUES (?, ?, ?, ?)',
-                (new_path, new_mtime, new_sha1, ts()),
-            )
-            return new_path
+            return stored_path
+
+        # no rename, just a new file with the same hash
+        cur.execute(
+            'INSERT INTO bitrot VALUES (?, ?, ?, ?)',
+            (new_path, new_mtime, new_sha1, ts()),
+        )
+        return new_path
 
 def get_path(directory=b'.', ext=b'db'):
     """Compose the path to the selected bitrot file."""
@@ -404,49 +697,71 @@ def stable_sum(bitrot_db=None):
         row = cur.fetchone()
     return digest.hexdigest()
 
-
-def check_sha512_integrity(verbosity=1):
+def check_sha512_integrity(verbosity=1, log=1):
     sha512_path = get_path(ext=b'sha512')
     if not os.path.exists(sha512_path):
         return
 
+    bitrot_db = get_path()
+    if not os.path.exists(bitrot_db):
+        return
+
     if verbosity:
         print('Checking bitrot.db integrity... ', end='')
+        if (log):
+            writeToLog(stringToWrite='\nChecking bitrot.db integrity... ')
         sys.stdout.flush()
     with open(sha512_path, 'rb') as f:
         old_sha512 = f.read().strip()
-    bitrot_db = get_path()
+    
     digest = hashlib.sha512()
     with open(bitrot_db, 'rb') as f:
         digest.update(f.read())
     new_sha512 = digest.hexdigest().encode('ascii')
     if new_sha512 != old_sha512:
-        if verbosity:
-            if len(old_sha512) == 128:
-                print(
-                    "error: SHA512 of the file is different, bitrot.db might "
-                    "be corrupt.",
-                )
-            else:
-                print(
-                    "error: SHA512 of the file is different but bitrot.sha512 "
-                    "has a suspicious length. It might be corrupt.",
-                )
+        if len(old_sha512) == 128:
             print(
-                "If you'd like to continue anyway, delete the .bitrot.sha512 "
-                "file and try again.",
-                file=sys.stderr,
+                "\nError: SHA512 of the database file is different, bitrot.db might "
+                "be corrupt.",
             )
+            if (log):
+                writeToLog(stringToWrite=
+                "\nError: SHA512 of the database file is different, bitrot.db might "
+                "be corrupt.",
+            )
+        else:
+            print(
+                "\nError: SHA512 of the database file is different, but bitrot.sha512 "
+                "has a suspicious length. It might be corrupt.",
+            )
+            if (log):
+                writeToLog(stringToWrite=
+                "\nError: SHA512 of the database file is different, but bitrot.sha512 "
+                "has a suspicious length. It might be corrupt.",
+            )
+        print(
+            "If you'd like to continue anyway, delete the .bitrot.sha512 "
+            "file and try again.",
+            file=sys.stderr,
+        )
+        if (log):
+            writeToLog(stringToWrite=
+            "\nIf you'd like to continue anyway, delete the .bitrot.sha512 file and try again.")
+            writeToLog(stringToWrite="\nbitrot.db integrity check failed, cannot continue.")
+
         raise BitrotException(
             3, 'bitrot.db integrity check failed, cannot continue.',
         )
 
     if verbosity:
         print('ok.')
+        if (log):
+            writeToLog(stringToWrite='ok.')
 
-def update_sha512_integrity(verbosity=1):
+def update_sha512_integrity(verbosity=1, log=1):
     old_sha512 = 0
     sha512_path = get_path(ext=b'sha512')
+
     if os.path.exists(sha512_path):
         with open(sha512_path, 'rb') as f:
             old_sha512 = f.read().strip()
@@ -458,15 +773,122 @@ def update_sha512_integrity(verbosity=1):
     if new_sha512 != old_sha512:
         if verbosity:
             print('Updating bitrot.sha512... ', end='')
+            if (log):
+                writeToLog(stringToWrite='\nUpdating bitrot.sha512... ')
             sys.stdout.flush()
         with open(sha512_path, 'wb') as f:
             f.write(new_sha512)
         if verbosity:
             print('done.')
+            if (log):
+                writeToLog(stringToWrite='done.')
+
+def recordTimeElapsed(startTime=0, log=1):
+    elapsedTime = (time.clock() - startTime)  
+    if (elapsedTime > 3600):
+        elapsedTime /= 3600
+        if ((int)(elapsedTime) == 1):
+            print('Time elapsed: 1 hour.')
+            if (log):
+                writeToLog(stringToWrite='\nTime elapsed: 1 hour.')
+        else:
+            print('Time elapsed: {:.1f} hours.'.format(elapsedTime))
+            if (log):
+                writeToLog(stringToWrite='\nTime elapsed: {:.1f} hours.'.format(elapsedTime))
+
+    elif (elapsedTime > 60):
+        elapsedTime /= 60
+        if ((int)(elapsedTime) == 1):
+            print('Time elapsed: 1 minute.')
+            if (log):
+                writeToLog(stringToWrite='\nTime elapsed: 1 minute.')
+        else:
+            print('Time elapsed: {:.0f} minutes.'.format(elapsedTime))
+            if (log):
+                writeToLog(stringToWrite='\nTime elapsed: {:.0f} minutes.'.format(elapsedTime))
+
+    else:
+        if ((int)(elapsedTime) == 1):
+            print('Time elapsed: 1 second.')
+            if (log):
+                writeToLog(stringToWrite='\nTime elapsed: 1 second.')
+        else:
+            print('Time elapsed: {:.0f} seconds.'.format(elapsedTime))
+            if (log):
+                 writeToLog(stringToWrite='\nTime elapsed: {:.1f} seconds.'.format(elapsedTime))
+
+def writeToLog(stringToWrite=""):
+    log_path = get_path(ext=b'log')
+    stringToWrite = cleanString(stringToWrite)
+    with open(log_path, 'a') as logFile:
+        logFile.write(stringToWrite)
+        logFile.close()
+
+def writeToSFV(stringToWrite="", sfv=""):
+    if (sfv == "MD5"):
+        sfv_path = get_path(ext=b'md5')
+    elif (sfv == "SFV"):
+        sfv_path = get_path(ext=b'sfv')
+    with open(sfv_path, 'a') as sfvFile:
+        sfvFile.write(stringToWrite)
+        sfvFile.close()
+
+def hash(path, chunk_size,hashing_function="",log=1,sfv=""):
+    if   (hashing_function == "MD5"):
+        digest=hashlib.md5()          
+    elif (hashing_function == "SHA1"):
+        digest=hashlib.sha1()
+    elif (hashing_function == "SHA224"):
+        digest=hashlib.sha224()
+    elif (hashing_function == "SHA384"):
+        digest=hashlib.sha384()
+    elif (hashing_function == "SHA256"):
+        digest=hashlib.sha256()
+    elif (hashing_function == "SHA512"):
+        digest=hashlib.sha512() 
+    else:
+        #You should never get here
+        if (log):
+            writeToLog(stringToWrite='\nInvalid hash function detected.')
+        raise Exception('Invalid hash function detected.')
+
+    with open(path, 'rb') as f:
+        d = f.read(chunk_size)
+        while d:
+            digest.update(d)
+            d = f.read(chunk_size)
+
+    if (sfv != ""):
+        strippedPathString = str(pathStripper(path,sfv))
+        if (sfv == "MD5" and hashing_function.upper() == "MD5"):
+            sfvDigest = digest.hexdigest()
+            writeToSFV(stringToWrite="{} {}\n".format(sfvDigest,strippedPathString),sfv=sfv) 
+        elif (sfv == "MD5"):
+            sfvDigest = hashlib.md5()
+            with open(path, 'rb') as f2:
+                d2 = f2.read(chunk_size)
+                while d2:
+                    sfvDigest.update(d2)
+                    d2 = f2.read(chunk_size)
+            writeToSFV(stringToWrite="{} {}\n".format(sfvDigest.hexdigest(),strippedPathString),sfv=sfv) 
+        elif (sfv == "SFV"):
+            crc=CRC32_from_file(path)
+            writeToSFV(stringToWrite="{} {}\n".format(strippedPathString,crc),sfv=sfv) 
+
+    return digest.hexdigest()
+
+def pathStripper(pathToStrip="",sfv=""):
+    pathToStripString = cleanString(str(pathToStrip))
+    pathToStripString = pathToStripString.replace("b'.\\\\", "")
+    pathToStripString = pathToStripString.replace("\\\\", "\\")
+    pathToStripString = pathToStripString[:-1]
+    if (sfv == "MD5"):
+        pathToStripString = "*" + pathToStripString
+    return pathToStripString
+
 
 def run_from_command_line():
     global FSENCODING
-
     parser = argparse.ArgumentParser(prog='bitrot')
     parser.add_argument(
         '-l', '--follow-links', action='store_true',
@@ -477,19 +899,10 @@ def run_from_command_line():
              'symbolic links registered during the first run will be '
              'properly followed and checked even if you run without `-l`.')
     parser.add_argument(
-        '-q', '--quiet', action='store_true',
-        help='don\'t print anything besides checksum errors')
-    parser.add_argument(
         '-s', '--sum', action='store_true',
         help='using only the data already gathered, return a SHA-512 sum '
              'of hashes of all the entries in the database. No timestamps '
              'are used in calculation.')
-    parser.add_argument(
-        '-v', '--verbose', action='store_true',
-        help='list new, updated and missing entries')
-    parser.add_argument(
-        '-t', '--test', action='store_true',
-        help='just test against an existing database, don\'t update anything')
     parser.add_argument(
         '--version', action='version',
         version='%(prog)s {}.{}.{}'.format(*VERSION))
@@ -504,6 +917,53 @@ def run_from_command_line():
         '--fsencoding', default='',
         help='override the codec to decode filenames, otherwise taken from '
              'the LANG environment variables')
+    parser.add_argument(
+        '-i', '--include-list', default='',
+        help='only read the files listed in this file (use - for stdin)')
+        # .\Directory\1.hi
+    parser.add_argument(
+        '-t', '--test', action='store_true',
+        help='just test against an existing database, don\'t update anything')
+    parser.add_argument(
+        '-a', '--hashing-function', default='',
+        help='Doesnt compare dates, only hashes. Also enables test-only mode')
+    parser.add_argument(
+        '-x', '--exclude-list', default='',
+        help="don't read the files listed in this file - wildcards are allowed")
+        #Samples: 
+        # *DirectoryA
+        # DirectoryB*
+        # DirectoryC
+        # *DirectoryD*
+        # *FileA
+        # FileB*
+        # FileC
+        # .\RelativeDirectoryE\*
+        # .\RelativeDirectoryF\DirectoryG\*
+        # *DirectoryH\DirectoryJ\*
+        # .\RelativeDirectoryK\DirectoryL\FileD
+        # .\RelativeDirectoryK\DirectoryL\FileD*
+        # *DirectoryM\DirectoryN\FileE.txt
+        # *DirectoryO\DirectoryP\FileF*
+    parser.add_argument(
+        '-v', '--verbose', default=1,
+        help='Level 0: Don\'t print anything besides checksum errors.\n'
+        'Level 1: Normal amount of verbosity.\n'
+        'Level 2: List new, updated and missing entries.\n'
+        'Level 3: List new, updated and missing entries, and ignored files.\n')
+    parser.add_argument(
+        '-n', '--no-time', action='store_true',
+        help='Doesnt compare dates, only hashes. Also enables test-only mode')
+    parser.add_argument(
+        '-e', '--email', action='store_true',
+        help='email file integirty errors')
+    parser.add_argument(
+        '-g', '--log', action='store_true',
+        help='logs activity')
+    parser.add_argument(
+        '-c', '--sfv', default='',
+        help='Also generates an MD5 or SFV file when given either of these as a parameter')
+
     args = parser.parse_args()
     if args.sum:
         try:
@@ -511,26 +971,127 @@ def run_from_command_line():
         except RuntimeError as e:
             print(str(e).encode('utf8'), file=sys.stderr)
     else:
-        verbosity = 1
-        if args.quiet:
-            verbosity = 0
-        elif args.verbose:
-            verbosity = 2
+        if args.verbose:
+            verbosity = int(args.verbose)
+            if (verbosity != 0 and verbosity != 1 and verbosity != 2 and verbosity != 3):
+                verbosity = 1
+
+        if (args.log):
+            log_path = get_path(ext=b'log')
+            if (verbosity):
+                if os.path.exists(log_path):
+                    writeToLog(stringToWrite='\n')
+                    writeToLog(stringToWrite='======================================================\n')
+                writeToLog(stringToWrite='Log started at ')
+                writeToLog(stringToWrite=datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
+        if args.no_time:
+            no_time = 1
+            args.test = 1
+        if args.include_list == '-':
+            if verbosity:
+                print('Using stdin for file list')
+                if (args.log):
+                   writeToLog(stringToWrite='\nUsing stdin for file list') 
+            include_list = sys.stdin
+        elif args.include_list:
+            if verbosity:
+                print('Opening file inclusion list at ', args.include_list)
+                if (args.log):
+                    writeToLog(stringToWrite='\nOpening file inclusion list at {}'.format(args.include_list))
+            #include_list = open(args.include)
+            include_list = [line.rstrip('\n').encode(FSENCODING) for line in open(args.include_list)]
+        else:
+            include_list = []
+        if args.exclude_list:
+            if verbosity:
+                print('Opening exclude list in', args.exclude_list)
+                if (args.log):
+                    writeToLog(stringToWrite='\nOpening exclude list in')
+                    writeToLog(stringToWrite=args.exclude_list)
+            exclude_list = [line.rstrip('\n').encode(FSENCODING) for line in open(args.exclude_list)]
+        else:
+            exclude_list = []
+
+        if (args.hashing_function):
+            #combined = '\t'.join(hashlib.algorithms_available)
+            #if (args.hashing_function in combined):
+
+            #word_to_check = args.hashing_function
+            #wordlist = hashlib.algorithms_available
+            #result = any(word_to_check in word for word in wordlist)
+
+            #algorithms_available = hashlib.algorithms_available
+            #search = args.hashing_function
+            #result = next((True for algorithms_available in algorithms_available if search in algorithms_available), False)
+            if (isValidHashingFunction(stringToValidate=args.hashing_function.upper()) == True):
+                hashing_function = args.hashing_function.upper()
+                if (verbosity):
+                    print('Using {} for hashing function.'.format(hashing_function))   
+                    if (args.log):
+                       writeToLog(stringToWrite='\nUsing {} for hashing function.'.format(hashing_function))
+            else:
+                if (verbosity):
+                    print("Invalid hashing function specified: {}. Using default {}.".format(args.hashing_function,DEFAULT_HASH_FUNCTION))
+                    if (args.log):
+                        writeToLog(stringToWrite="\nInvalid hashing function specified: {}. Using default {}.".format(args.hashing_function,DEFAULT_HASH_FUNCTION))
+                hashing_function = DEFAULT_HASH_FUNCTION
+        else:
+            hashing_function = DEFAULT_HASH_FUNCTION
+
+        sfv_path = get_path(ext=b'sfv')
+        md5_path = get_path(ext=b'md5')
+        try:
+            os.remove(sfv_path)
+        except Exception as err:
+            pass
+        try:
+            os.remove(md5_path)
+        except Exception as err:
+            pass
+        if (args.sfv):
+            if (args.sfv.upper() == "MD5" or args.sfv.upper() == "SFV"): 
+                sfv = args.sfv.upper() 
+                if (verbosity):
+                    print('Will generate an {} file.'.format(sfv))   
+                    if (args.log):
+                       writeToLog('\nWill generate an {} file.'.format(sfv)) 
+            else:
+                if (verbosity):
+                    print("Invalid SFV/MD5 filetype specified: {}. Will not generate any additional file.".format(args.sfv))
+                    if (args.log):
+                        writeToLog("\nInvalid SFV/MD5 filetype specified: {}. Will not generate any additional file.".format(args.sfv))
+                sfv = ""
+        else:
+            sfv = ""
+
         bt = Bitrot(
             verbosity=verbosity,
+            hashing_function=hashing_function,
             test=args.test,
+            email=args.email,
+            log = args.log,
+            no_time = args.no_time,
             follow_links=args.follow_links,
             commit_interval=args.commit_interval,
             chunk_size=args.chunk_size,
+            include_list=include_list,
+            exclude_list=exclude_list,
+            sfv=sfv,
         )
         if args.fsencoding:
             FSENCODING = args.fsencoding
+
         try:
             bt.run()
         except BitrotException as bre:
-            print('error:', bre.args[1], file=sys.stderr)
+            print('Error:', bre.args[1], file=sys.stderr)
+            if (args.log):
+                writeToLog(stringToWrite='\nError: ')
+                writeToLog(stringToWrite=bre.args[1])
             sys.exit(bre.args[0])
 
+        #if include_list:
+        #    include_list.close() # should be harmless if include_list == sys.stdin
 
 if __name__ == '__main__':
     run_from_command_line()

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -67,7 +67,7 @@ def sendMail(stringToSend="", log=1, verbosity=1, subject=""):
     msg['From'] = email.utils.formataddr(('Author', 'recipient@gmail.com'))
     USERNAME = 'authorUsername'
     PASSWORD = 'authorPassword'
-    
+
     try:
         msg['Subject'] = subject
         # The actual mail send
@@ -683,13 +683,13 @@ class Bitrot(object):
                 writeToLog('\n\nFinished. {:.2f} {} of data read. {} errors found.'.format(total_size, sizeUnits, error_count))
 
         if (warning_count == 1):
-            print('1 warning found.')
+            print(' 1 warning found.')
             if (self.log):
-                writeToLog('1 warning found')
+                writeToLog(' 1 warning found.')
         else:
-            print('{} warnings found.'.format(warning_count))
+            print(' {} warnings found.'.format(warning_count))
             if (self.log):
-                writeToLog('{} warnings found.'.format(warning_count))
+                writeToLog(' {} warnings found.'.format(warning_count))
 
         if self.verbosity == 1:
             if (all_count == 1):

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -207,7 +207,7 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=True, warnings = (),
                     fixedRenameList.append([])
                     fixedRenameList.append([])
                     fixedRenameList[fixedRenameCounter].append(os.path.join(root, p_uniBackup))
-                    fixedRenameList[fixedRenameCounter].append(os.path.join(root, cleanString(f)))
+                    fixedRenameList[fixedRenameCounter].append(os.path.join(root, p_uni))
                     fixedRenameCounter += 1
 
         for d in dirs:
@@ -235,7 +235,7 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=True, warnings = (),
                     fixedRenameList.append([])
                     fixedRenameList.append([])
                     fixedRenameList[fixedRenameCounter].append(os.path.join(root, p_uniBackup))
-                    fixedRenameList[fixedRenameCounter].append(os.path.join(root, cleanString(d)))
+                    fixedRenameList[fixedRenameCounter].append(os.path.join(root, p_uni))
                     fixedRenameCounter += 1
     return fixedRenameList, fixedRenameCounter
 

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -191,7 +191,6 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=True, warnings = (),
                     #os.rename(f, cleanString(f))  # relative path, more elegant
                     os.rename(os.path.join(root, f), os.path.join(root, cleanString(f)))
                     p_uni = cleanString(f)
-                    writeToLog("Test")
                 except Exception as ex:
                     warnings.append(f)
                     print(
@@ -206,8 +205,8 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=True, warnings = (),
                 else:
                     fixedRenameList.append([])
                     fixedRenameList.append([])
-                    fixedRenameList[fixedRenameCounter].append(f)
-                    fixedRenameList[fixedRenameCounter].append(f)
+                    fixedRenameList[fixedRenameCounter].append(os.path.join(root, f))
+                    fixedRenameList[fixedRenameCounter].append(os.path.join(root, cleanString(f)))
                     fixedRenameCounter += 1
 
         for d in dirs:
@@ -233,8 +232,8 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=True, warnings = (),
                 else:
                     fixedRenameList.append([])
                     fixedRenameList.append([])
-                    fixedRenameList[fixedRenameCounter].append(d)
-                    fixedRenameList[fixedRenameCounter].append(d)
+                    fixedRenameList[fixedRenameCounter].append(os.path.join(root, d))
+                    fixedRenameList[fixedRenameCounter].append(os.path.join(root, cleanString(d)))
                     fixedRenameCounter += 1
     return fixedRenameList, fixedRenameCounter
 
@@ -373,18 +372,16 @@ class Bitrot(object):
                 
         missing_paths = self.select_all_paths(cur)
 
-       
-
-        # if (self.fix == True):
-        #     fixedRenameList, fixedRenameCounter = fix_existing_paths(
-        #     os.getcwd(),# pass an unambiguous string instead of: b'.'  
-        #     verbosity=self.verbosity,
-        #     log=self.log,
-        #     fix=self.fix,
-        #     warnings=warnings,
-        #     fixedRenameList = fixedRenameList,
-        #     fixedRenameCounter = fixedRenameCounter
-        # )
+        if (self.fix == True):
+            fixedRenameList, fixedRenameCounter = fix_existing_paths(
+            os.getcwd(),# pass an unambiguous string instead of: b'.'  
+            verbosity=self.verbosity,
+            log=self.log,
+            fix=self.fix,
+            warnings=warnings,
+            fixedRenameList = fixedRenameList,
+            fixedRenameCounter = fixedRenameCounter
+        )
 
 
         paths, total_size, ignoredList = list_existing_paths(

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -1232,7 +1232,7 @@ def run_from_command_line():
                     writeToLog('======================================================\n')
                 writeToLog('Log started at ')
                 writeToLog(datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
-
+        include_list = []
         if args.include_list == '-':
             if verbosity:
                 print('Using stdin for file list')
@@ -1241,12 +1241,15 @@ def run_from_command_line():
             include_list = sys.stdin
         elif args.include_list:
             if verbosity:
-                print('Opening file inclusion list at `{}`', args.include_list)
+                print('Opening file inclusion list at `{}`'.format(args.include_list))
                 if (args.log):
                     writeToLog('\nOpening file inclusion list at `{}`'.format(args.include_list))
-            #include_list = open(args.include)
             try:
-                include_list = [line.rstrip('\n').encode(FSENCODING) for line in open(args.include_list)]
+                #include_list = [line.rstrip('\n').encode(FSENCODING) for line in open(args.include_list)]
+                with open(args.include_list) as includeFile:
+                    for line in includeFile:
+                        line = line.rstrip('\n').encode(FSENCODING)
+                        include_list.append(line)
             except Exception as err:
                 if (verbosity):
                     print("Invalid inclusion list specified: `{}`. Not using an inclusion list. Received error: {}".format(args.include_list, err))
@@ -1255,15 +1258,18 @@ def run_from_command_line():
                 include_list = []
         else:
             include_list = []
-
+        exclude_list = []
         if args.exclude_list:
             if verbosity:
-                print('Opening file exclusion list at `{}`', args.exclude_list)
+                print('Opening file exclusion list at `{}`'.format(args.exclude_list))
                 if (args.log):
-                    writeToLog('\nOpening file exclusion list at `{}`')
-                    writeToLog(args.exclude_list)
+                    writeToLog('\nOpening file exclusion list at `{}`'.format(args.exclude_list))
             try:
-                exclude_list = [line.rstrip('\n').encode(FSENCODING) for line in open(args.exclude_list)]
+                # exclude_list = [line.rstrip('\n').encode(FSENCODING) for line in open(args.exclude_list)]
+                with open(args.exclude_list) as excludeFile:
+                    for line in excludeFile:
+                        line = line.rstrip('\n').encode(FSENCODING)
+                        exclude_list.append(line)
             except Exception as err:
                 if (verbosity):
                     print("Invalid exclusion list specified: `{}`. Not using an exclusion list. Received error: {}".format(args.exclude_list, err))
@@ -1416,8 +1422,11 @@ def run_from_command_line():
                 writeToLog(bre.args[1])
             sys.exit(bre.args[0])
 
-        #if include_list:
-        #    include_list.close() # should be harmless if include_list == sys.stdin
+        if includeFile:
+            includeFile.close() # should be harmless if include_list == sys.stdin
+
+        #if excludeFile:
+            # excludeFile.close() # should be harmless if include_list == sys.stdin
 
 if __name__ == '__main__':
     run_from_command_line()

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -1190,7 +1190,7 @@ def run_from_command_line():
         'Level 4: List missing, fixed, new, renamed, and updated entries, and ignored files.\n')
     parser.add_argument(
         '-e', '--email', action='store_true',
-        help='email file integirty errors')
+        help='email file integrity errors')
     parser.add_argument(
         '-g', '--log', action='store_true',
         help='logs activity')

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -79,7 +79,16 @@ def sendMail(stringToSend="", log=1, verbosity=1, subject=""):
     except Exception as err:
         print('Email sending error:', err)
         if (log):
-            writeToLog(stringToWrite='\n\nEmail sending error: {}'.format(err))
+            writeToLog('\n\nEmail sending error: {}'.format(err))
+
+def is_int(val):
+    if type(val) == int:
+        return True
+    else:
+        if val.is_integer():
+            return True
+        else:
+            return False
 
 def isValidHashingFunction(stringToValidate=""):
     if  (stringToValidate == "SHA1"
@@ -150,7 +159,7 @@ def get_sqlite3_cursor(path, copy=False):
             raise ValueError("Error: bitrot database at {} does not exist."
                              "".format(path))
             if (self.log):
-                writeToLog(stringToWrite="\nError: bitrot database at {} does not exist."
+                writeToLog("\nError: bitrot database at {} does not exist."
                     "".format(path))
         db_copy = tempfile.NamedTemporaryFile(prefix='bitrot_', suffix='.db',
                                               delete=False)
@@ -202,7 +211,7 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=1, warnings = (), fi
                         file=sys.stderr,
                     )
                     if (log):
-                        writeToLog(stringToWrite='\rCan\'t rename: {} due to warning: `{}`'.format(os.path.join(root, f),ex))
+                        writeToLog('\rCan\'t rename: {} due to warning: `{}`'.format(os.path.join(root, f),ex))
                     continue
                 else:
                     fixedRenameList.append([])
@@ -231,7 +240,7 @@ def fix_existing_paths(directory, verbosity = 1, log=1, fix=1, warnings = (), fi
                         file=sys.stderr,
                     )
                     if (log):
-                        writeToLog(stringToWrite='\rCan\'t rename: {} due to warning: `{}`'.format(os.path.join(root, d),ex))
+                        writeToLog('\rCan\'t rename: {} due to warning: `{}`'.format(os.path.join(root, d),ex))
                     continue
                 else:
                     fixedRenameList.append([])
@@ -267,7 +276,7 @@ def list_existing_paths(directory, expected=(), ignored=(), included=(),
                 binary_stderr.write(p)
                 binary_stderr.write(b"\n")
                 if (log):
-                    writeToLog(stringToWrite="\nWarning: cannot decode file name: {}".format(p))
+                    writeToLog("\nWarning: cannot decode file name: {}".format(p))
                 continue
 
             try:
@@ -297,8 +306,8 @@ def list_existing_paths(directory, expected=(), ignored=(), included=(),
                         #print('Ignoring file: {}'.format(p))
                         #print('Ignoring file: {}'.format(p.decode(FSENCODING)))
                         #if (log):
-                            #writeToLog(stringToWrite="\nIgnoring file: {}".format(p))
-                            #writeToLog(stringToWrite="\nIgnoring file: {}".format(p.decode(FSENCODING)))
+                            #writeToLog("\nIgnoring file: {}".format(p))
+                            #writeToLog("\nIgnoring file: {}".format(p.decode(FSENCODING)))
                     continue
                 paths.append(p)
                 total_size += st.st_size
@@ -358,7 +367,7 @@ class Bitrot(object):
                 'No database exists so cannot test. Run the tool once first.',
             )
             if (self.log):
-                writeToLog(stringToWrite="\nNo database exists so cannot test. Run the tool once first.")
+                writeToLog("\nNo database exists so cannot test. Run the tool once first.")
 
         cur = conn.cursor()
         new_paths = []
@@ -421,8 +430,8 @@ class Bitrot(object):
                         file=sys.stderr,
                     )
                     if (self.log):
-                        #writeToLog(stringToWrite='\nWarning: `{}` is currently unavailable for reading: {}'.format(p_uni, ex))
-                        writeToLog(stringToWrite='\nWarning: `{}` is currently unavailable for reading: {}'.format(p.decode(FSENCODING), ex))
+                        #writeToLog('\nWarning: `{}` is currently unavailable for reading: {}'.format(p_uni, ex))
+                        writeToLog('\nWarning: `{}` is currently unavailable for reading: {}'.format(p.decode(FSENCODING), ex))
                     continue
 
                 raise   # Not expected? https://github.com/ambv/bitrot/issues/
@@ -464,7 +473,7 @@ class Bitrot(object):
                     file=sys.stderr,
                 )
                 if (self.log):
-                    writeToLog(stringToWrite='\nWarning: `{}` has an invalid modification date. Try running with -f to fix. Received error: {}'.format(p.decode(FSENCODING), ex))
+                    writeToLog('\nWarning: `{}` has an invalid modification date. Try running with -f to fix. Received error: {}'.format(p.decode(FSENCODING), ex))
             try:
                 c = datetime.datetime.fromtimestamp(new_atime)
             except Exception as ex:
@@ -476,13 +485,12 @@ class Bitrot(object):
                     file=sys.stderr,
                 )
                 if (self.log):
-                    writeToLog(stringToWrite='\nWarning: `{}` has an invalid access date. Try running with -f to fix. Received error: {}'.format(p.decode(FSENCODING), ex))
+                    writeToLog('\nWarning: `{}` has an invalid access date. Try running with -f to fix. Received error: {}'.format(p.decode(FSENCODING), ex))
                    
             
-            if (self.test >= 3):
+            if (self.test == 3):
                 delta = a - b
                 delta2= a - c
-                print("accessed: {} modified: {}".format(delta.days,delta2.days))
                 if (delta.days >= RECENT or delta2.days >= RECENT):
                     tooOldList.append(p_uni)
                     missing_paths.discard(p_uni)
@@ -506,7 +514,7 @@ class Bitrot(object):
                     file=sys.stderr,
                 )
                 if (self.log):
-                    writeToLog(stringToWrite='\n\nWarning: cannot compute hash of {} [{}]'.format(
+                    writeToLog('\n\nWarning: cannot compute hash of {} [{}]'.format(
                             #p, errno.errorcode[e.args[0]]))
                             p.decode(FSENCODING), errno.errorcode[e.args[0]]))
                 continue
@@ -528,7 +536,7 @@ class Bitrot(object):
                 continue
             stored_mtime, stored_hash, stored_ts = row
 
-            if (int(stored_mtime) != new_mtime) and not (self.test >= 2):
+            if (int(stored_mtime) != new_mtime) and not (self.test == 2):
                 updated_paths.append(p)
                 cur.execute('UPDATE bitrot SET mtime=?, hash=?, timestamp=? '
                             'WHERE path=?',
@@ -554,7 +562,7 @@ class Bitrot(object):
                     file=sys.stderr,
                 )
                 if (self.log):
-                    writeToLog(stringToWrite=
+                    writeToLog(
                         '\n\nError: {} mismatch for {}\nExpected: {}\nGot:          {}'
                         '\nLast good hash checked on {}'.format(
                         #p, stored_hash, new_hash, stored_ts
@@ -606,11 +614,11 @@ class Bitrot(object):
             if len(warnings) == 1:
                 print('Warning: There was 1 warning found.')
                 if (self.log):
-                    writeToLog(stringToWrite='\nWarning: There was 1 warning found.')
+                    writeToLog('\nWarning: There was 1 warning found.')
             else:
                 print('Warning: There were {} warnings found.'.format(len(warnings)))
                 if (self.log):
-                    writeToLog(stringToWrite='\nWarning: There were {} warnings found.'.format(len(warnings)))
+                    writeToLog('\nWarning: There were {} warnings found.'.format(len(warnings)))
 
         if errors:
             if len(errors) == 1:
@@ -668,20 +676,20 @@ class Bitrot(object):
         if (error_count == 1):
                 print('\rFinished. {:.2f} {} of data read. 1 error found. '.format(total_size,sizeUnits),end="")
                 if (self.log):
-                    writeToLog(stringToWrite='\n\nFinished. {:.2f} {} of data read. '.format(total_size,sizeUnits))
+                    writeToLog('\n\nFinished. {:.2f} {} of data read. '.format(total_size,sizeUnits))
         else:
             print('\rFinished. {:.2f} {} of data read. {} errors found. '.format(total_size, sizeUnits, error_count),end="")
             if (self.log):
-                writeToLog(stringToWrite='\n\nFinished. {:.2f} MiB of data read. {} errors found. '.format(total_size, error_count, sizeUnits))
+                writeToLog('\n\nFinished. {:.2f} MiB of data read. {} errors found. '.format(total_size, error_count, sizeUnits))
 
         if (warning_count == 1):
             print('1 warning found.')
             if (self.log):
-                writeToLog(stringToWrite='1 warning found')
+                writeToLog('1 warning found')
         else:
             print('{} warnings found.'.format(warning_count))
             if (self.log):
-                writeToLog(stringToWrite='{} warnings found.'.format(warning_count))
+                writeToLog('{} warnings found.'.format(warning_count))
 
         if self.verbosity == 1:
             if (all_count == 1):
@@ -691,7 +699,7 @@ class Bitrot(object):
                         len(new_paths), len(updated_paths),
                         len(renamed_paths), len(missing_paths), totalFixed))
                 if (self.log):
-                    writeToLog(stringToWrite=
+                    writeToLog(
                     '\n1 entry in the database, {} new, {} updated, '
                     '{} renamed, {} missing, {} fixed'.format(
                         len(new_paths), len(updated_paths),
@@ -703,7 +711,7 @@ class Bitrot(object):
                     all_count, len(new_paths), len(updated_paths),
                     len(renamed_paths), len(missing_paths), totalFixed))
                 if (self.log):
-                    writeToLog(stringToWrite=
+                    writeToLog(
                     '\n{} entries in the database, {} new, {} updated, '
                     '{} renamed, {} missing, {} fixed.'.format(
                         all_count, len(new_paths), len(updated_paths),
@@ -713,11 +721,11 @@ class Bitrot(object):
             if (all_count == 1):
                 print('1 entry in the database.')
                 if (self.log):
-                    writeToLog(stringToWrite='1 entry in the database.')
+                    writeToLog('1 entry in the database.')
             else:
                 print('{} entries in the database.'.format(all_count), end=' ')
                 if (self.log):
-                    writeToLog(stringToWrite='\n{} entries in the database.'.format(all_count))
+                    writeToLog('\n{} entries in the database.'.format(all_count))
 
         if self.verbosity >= 4:
             if (ignoredList):
@@ -761,43 +769,43 @@ class Bitrot(object):
                 if (len(new_paths) == 1):
                     print('\n1 new entry:')
                     if (self.log):
-                        writeToLog(stringToWrite='\n\n1 new entry:')
+                        writeToLog('\n\n1 new entry:')
                 else:
                     print('\n{} new entries:'.format(len(new_paths)))
                     if (self.log):
-                        writeToLog(stringToWrite='\n\n{} new entries:'.format(len(new_paths)))
+                        writeToLog('\n\n{} new entries:'.format(len(new_paths)))
 
                 new_paths.sort()
                 for path in new_paths:
                     print(' ', path.decode(FSENCODING))
                     if (self.log):
-                        writeToLog(stringToWrite='\n {}'.format(path.decode(FSENCODING)))
+                        writeToLog('\n {}'.format(path.decode(FSENCODING)))
 
             if updated_paths:
                 if (len(updated_paths) == 1):
                     print('\n1 entry updated:')
                     if (self.log):
-                        writeToLog(stringToWrite='\n\n1 entry updated:')
+                        writeToLog('\n\n1 entry updated:')
                 else:
                     print('\n{} entries updated:'.format(len(updated_paths)))
                     if (self.log):
-                        writeToLog(stringToWrite='\n\n{} entries updated:'.format(len(updated_paths)))
+                        writeToLog('\n\n{} entries updated:'.format(len(updated_paths)))
 
                 updated_paths.sort()
                 for path in updated_paths:
                     print(' ', path.decode(FSENCODING))
                     if (self.log):
-                        writeToLog(stringToWrite='\n {}'.format(path.decode(FSENCODING)))
+                        writeToLog('\n {}'.format(path.decode(FSENCODING)))
 
             if renamed_paths:
                 if (len(renamed_paths) == 1):
                     print('\n1 entry renamed:')
                     if (self.log):
-                        writeToLog(stringToWrite='\n\n1 entry renamed:')
+                        writeToLog('\n\n1 entry renamed:')
                 else:
                     print('\n{} entries renamed:'.format(len(renamed_paths)))
                     if (self.log):
-                        writeToLog(stringToWrite='\n\n{} entries renamed:'.format(len(renamed_paths)))
+                        writeToLog('\n\n{} entries renamed:'.format(len(renamed_paths)))
 
                 renamed_paths.sort()
                 for path in renamed_paths:
@@ -810,64 +818,64 @@ class Bitrot(object):
                         path[1],
                     )
                     if (self.log):
-                        writeToLog(stringToWrite='\n from {} to {}'.format(path[0],path[1]))
+                        writeToLog('\n from {} to {}'.format(path[0],path[1]))
                     
         if self.verbosity >= 2:
             if missing_paths:
                 if (len(missing_paths) == 1):
                     print('\n1 entry missing:')
                     if (self.log):
-                        writeToLog(stringToWrite='\n\n1 entry missing:')
+                        writeToLog('\n\n1 entry missing:')
                 else:
                     print('\n{} entries missing:'.format(len(missing_paths)))
                     if (self.log):
-                        writeToLog(stringToWrite='\n\n{} entries missing:'.format(len(missing_paths)))
+                        writeToLog('\n\n{} entries missing:'.format(len(missing_paths)))
 
                 missing_paths = sorted(missing_paths)
                 for path in missing_paths:
                     print(' ', path)
                     if (self.log):
-                        writeToLog(stringToWrite='\n {}'.format(path))
+                        writeToLog('\n {}'.format(path))
 
             if fixedRenameList:
                 if (len(fixedRenameList) == 1):
                     print('\n1 filename fixed:')
                     if (self.log):
-                        writeToLog(stringToWrite='\n\n1 filename fixed:')
+                        writeToLog('\n\n1 filename fixed:')
                 else:
                     print('\n{} filenames fixed:'.format(fixedRenameCounter))
                     if (self.log):
-                        writeToLog(stringToWrite='\n\n{} filenames fixed:'.format(fixedRenameCounter))
+                        writeToLog('\n\n{} filenames fixed:'.format(fixedRenameCounter))
 
                 for i in range(0, fixedRenameCounter):
                     print('  renamed `{}` to `{}`'.format(fixedRenameList[i][0],fixedRenameList[i][1]))
                     if (self.log):
-                        writeToLog(stringToWrite='\n  `{}` to `{}`'.format(fixedRenameList[i][0],fixedRenameList[i][1]))
+                        writeToLog('\n  `{}` to `{}`'.format(fixedRenameList[i][0],fixedRenameList[i][1]))
            
             if fixedPropertiesList:
                 if (len(fixedPropertiesList) == 1):
                     print('\n1 file property fixed:')
                     if (self.log):
-                        writeToLog(stringToWrite='\n\n1 file property fixed:')
+                        writeToLog('\n\n1 file property fixed:')
                 else:
                     print('\n{} file properties fixed:'.format(fixedPropertiesCounter))
                     if (self.log):
-                        writeToLog(stringToWrite='\n\n{} file properties fixed:'.format(fixedPropertiesCounter))
+                        writeToLog('\n\n{} file properties fixed:'.format(fixedPropertiesCounter))
 
                 for i in range(0, fixedPropertiesCounter):
                     print('  Added missing modification time to {}'.format(fixedPropertiesList[i][0]))
                     if (self.log):
-                        writeToLog(stringToWrite='  Added missing modification time to {}'.format(fixedPropertiesList[i][0]))
+                        writeToLog('  Added missing modification time to {}'.format(fixedPropertiesList[i][0]))
             
                         
         if any((new_paths, updated_paths, missing_paths, renamed_paths, ignoredList, tooOldList)):
             if (self.log):
-                writeToLog(stringToWrite='\n')
+                writeToLog('\n')
 
         if self.test and self.verbosity:
             print('\nDatabase file not updated on disk (test mode).')
             if (self.log):
-                writeToLog(stringToWrite='\nDatabase file not updated on disk (test mode).')
+                writeToLog('\nDatabase file not updated on disk (test mode).')
 
     def handle_unknown_path(self, cur, new_path, new_mtime, new_sha1):
         """Either add a new entry to the database or update the existing entry
@@ -933,7 +941,7 @@ def check_sha512_integrity(verbosity=1, log=1):
     if verbosity:
         print('Checking bitrot.db integrity... ', end='')
         if (log):
-            writeToLog(stringToWrite='\nChecking bitrot.db integrity... ')
+            writeToLog('\nChecking bitrot.db integrity... ')
         sys.stdout.flush()
     with open(sha512_path, 'rb') as f:
         old_sha512 = f.read().strip()
@@ -949,7 +957,7 @@ def check_sha512_integrity(verbosity=1, log=1):
                 "be corrupt.",
             )
             if (log):
-                writeToLog(stringToWrite=
+                writeToLog(
                 "\nError: SHA512 of the database file is different, bitrot.db might "
                 "be corrupt.",
             )
@@ -959,7 +967,7 @@ def check_sha512_integrity(verbosity=1, log=1):
                 "has a suspicious length. It might be corrupt.",
             )
             if (log):
-                writeToLog(stringToWrite=
+                writeToLog(
                 "\nError: SHA512 of the database file is different, but bitrot.sha512 "
                 "has a suspicious length. It might be corrupt.",
             )
@@ -969,9 +977,9 @@ def check_sha512_integrity(verbosity=1, log=1):
             file=sys.stderr,
         )
         if (log):
-            writeToLog(stringToWrite=
+            writeToLog(
             "\nIf you'd like to continue anyway, delete the .bitrot.sha512 file and try again.")
-            writeToLog(stringToWrite="\nbitrot.db integrity check failed, cannot continue.")
+            writeToLog("\nbitrot.db integrity check failed, cannot continue.")
 
         raise BitrotException(
             3, 'bitrot.db integrity check failed, cannot continue.',
@@ -980,7 +988,7 @@ def check_sha512_integrity(verbosity=1, log=1):
     if verbosity:
         print('ok.')
         if (log):
-            writeToLog(stringToWrite='ok.')
+            writeToLog('ok.')
 
 def update_sha512_integrity(verbosity=1, log=1):
     old_sha512 = 0
@@ -998,14 +1006,14 @@ def update_sha512_integrity(verbosity=1, log=1):
         if verbosity:
             print('Updating bitrot.sha512... ', end='')
             if (log):
-                writeToLog(stringToWrite='\nUpdating bitrot.sha512... ')
+                writeToLog('\nUpdating bitrot.sha512... ')
             sys.stdout.flush()
         with open(sha512_path, 'wb') as f:
             f.write(new_sha512)
         if verbosity:
             print('done.')
             if (log):
-                writeToLog(stringToWrite='done.')
+                writeToLog('done.')
 
 def recordTimeElapsed(startTime=0, log=1):
     elapsedTime = (time.time() - startTime)  
@@ -1014,32 +1022,32 @@ def recordTimeElapsed(startTime=0, log=1):
         if ((int)(elapsedTime) == 1):
             print('Time elapsed: 1 hour.')
             if (log):
-                writeToLog(stringToWrite='\nTime elapsed: 1 hour.')
+                writeToLog('\nTime elapsed: 1 hour.')
         else:
             print('Time elapsed: {:.1f} hours.'.format(elapsedTime))
             if (log):
-                writeToLog(stringToWrite='\nTime elapsed: {:.1f} hours.'.format(elapsedTime))
+                writeToLog('\nTime elapsed: {:.1f} hours.'.format(elapsedTime))
 
     elif (elapsedTime > 60):
         elapsedTime /= 60
         if ((int)(elapsedTime) == 1):
             print('Time elapsed: 1 minute.')
             if (log):
-                writeToLog(stringToWrite='\nTime elapsed: 1 minute.')
+                writeToLog('\nTime elapsed: 1 minute.')
         else:
             print('Time elapsed: {:.0f} minutes.'.format(elapsedTime))
             if (log):
-                writeToLog(stringToWrite='\nTime elapsed: {:.0f} minutes.'.format(elapsedTime))
+                writeToLog('\nTime elapsed: {:.0f} minutes.'.format(elapsedTime))
 
     else:
         if ((int)(elapsedTime) == 1):
             print('Time elapsed: 1 second.')
             if (log):
-                writeToLog(stringToWrite='\nTime elapsed: 1 second.')
+                writeToLog('\nTime elapsed: 1 second.')
         else:
             print('Time elapsed: {:.0f} seconds.'.format(elapsedTime))
             if (log):
-                 writeToLog(stringToWrite='\nTime elapsed: {:.1f} seconds.'.format(elapsedTime))
+                 writeToLog('\nTime elapsed: {:.1f} seconds.'.format(elapsedTime))
 
 def writeToLog(stringToWrite=""):
     log_path = get_path(ext=b'log')
@@ -1073,7 +1081,7 @@ def hash(path, chunk_size,hashing_function="",log=1,sfv=""):
     else:
         #You should never get here
         if (log):
-            writeToLog(stringToWrite='\nInvalid hash function detected.')
+            writeToLog('\nInvalid hash function detected.')
         raise Exception('Invalid hash function detected.')
 
     with open(path, 'rb') as f:
@@ -1148,7 +1156,7 @@ def run_from_command_line():
         '-t', '--test', default=0,
         help='Level 0: normal operations.\n'
         'Level 1: just test against an existing database, don\'t update anything.\n.'
-        'Level 2: Doesnt compare dates, only hashes.\n'
+        'Level 2: Doesnt compare dates, only hashes. No timestamps are used in the calculation.\n'
         'Level 3: Only compares recently modified or accessed data.\n')
     parser.add_argument(
         '-a', '--hashing-function', default='',
@@ -1188,7 +1196,7 @@ def run_from_command_line():
         '-c', '--sfv', default='',
         help='Also generates an MD5 or SFV file when given either of these as a parameter')
     parser.add_argument(
-        '-f', '--fix', default=1,
+        '-f', '--fix', default=0,
         help='Level 0: will not check for problem files.\n'
         'Level 1: Will report problem files.\n'
         'Level 2: Fixes files by removing invalid characters and adding missing modification times. NOT RECOMMENDED.')
@@ -1220,33 +1228,48 @@ def run_from_command_line():
             log_path = get_path(ext=b'log')
             if (verbosity):
                 if os.path.exists(log_path):
-                    writeToLog(stringToWrite='\n')
-                    writeToLog(stringToWrite='======================================================\n')
-                writeToLog(stringToWrite='Log started at ')
-                writeToLog(stringToWrite=datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
+                    writeToLog('\n')
+                    writeToLog('======================================================\n')
+                writeToLog('Log started at ')
+                writeToLog(datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
 
         if args.include_list == '-':
             if verbosity:
                 print('Using stdin for file list')
                 if (args.log):
-                   writeToLog(stringToWrite='\nUsing stdin for file list') 
+                   writeToLog('\nUsing stdin for file list') 
             include_list = sys.stdin
         elif args.include_list:
             if verbosity:
-                print('Opening file inclusion list at ', args.include_list)
+                print('Opening file inclusion list at `{}`', args.include_list)
                 if (args.log):
-                    writeToLog(stringToWrite='\nOpening file inclusion list at {}'.format(args.include_list))
+                    writeToLog('\nOpening file inclusion list at `{}`'.format(args.include_list))
             #include_list = open(args.include)
-            include_list = [line.rstrip('\n').encode(FSENCODING) for line in open(args.include_list)]
+            try:
+                include_list = [line.rstrip('\n').encode(FSENCODING) for line in open(args.include_list)]
+            except Exception as err:
+                if (verbosity):
+                    print("Invalid inclusion list specified: `{}`. Not using an inclusion list. Received error: {}".format(args.include_list, err))
+                    if (args.log):
+                        writeToLog("\nInvalid inclusion list specified: `{}`. Not using an inclusion list. Received error: {}".format(args.include_list, err))
+                include_list = []
         else:
             include_list = []
+
         if args.exclude_list:
             if verbosity:
-                print('Opening file exclusion list at', args.exclude_list)
+                print('Opening file exclusion list at `{}`', args.exclude_list)
                 if (args.log):
-                    writeToLog(stringToWrite='\nOpening file exclusion list at')
-                    writeToLog(stringToWrite=args.exclude_list)
-            exclude_list = [line.rstrip('\n').encode(FSENCODING) for line in open(args.exclude_list)]
+                    writeToLog('\nOpening file exclusion list at `{}`')
+                    writeToLog(args.exclude_list)
+            try:
+                exclude_list = [line.rstrip('\n').encode(FSENCODING) for line in open(args.exclude_list)]
+            except Exception as err:
+                if (verbosity):
+                    print("Invalid exclusion list specified: `{}`. Not using an exclusion list. Received error: {}".format(args.exclude_list, err))
+                    if (args.log):
+                        writeToLog("\nInvalid exclusion list specified: `{}`. Not using an exclusion list. Received error: {}".format(args.exclude_list, err))
+                exclude_list = []
         else:
             exclude_list = []
 
@@ -1266,12 +1289,12 @@ def run_from_command_line():
                 if (verbosity):
                     print('Using {} for hashing function.'.format(hashing_function))   
                     if (args.log):
-                       writeToLog(stringToWrite='\nUsing {} for hashing function.'.format(hashing_function))
+                       writeToLog('\nUsing {} for hashing function.'.format(hashing_function))
             else:
                 if (verbosity):
                     print("Invalid hashing function specified: {}. Using default {}.".format(args.hashing_function,DEFAULT_HASH_FUNCTION))
                     if (args.log):
-                        writeToLog(stringToWrite="\nInvalid hashing function specified: {}. Using default {}.".format(args.hashing_function,DEFAULT_HASH_FUNCTION))
+                        writeToLog("\nInvalid hashing function specified: {}. Using default {}.".format(args.hashing_function,DEFAULT_HASH_FUNCTION))
                 hashing_function = DEFAULT_HASH_FUNCTION
         else:
             hashing_function = DEFAULT_HASH_FUNCTION
@@ -1303,11 +1326,16 @@ def run_from_command_line():
             sfv = ""
 
         test = 0
-        try:
-            test = int(args.test)
-            if (test):
+        if (args.test):
+            try:
+                test = int(args.test)
                 if (verbosity):
-                    if (test == 1):
+                    if (test == 0):
+                        if (verbosity):
+                            print("Testing-only disabled.")
+                            if (args.log):
+                                writeToLog("\nTesting-only disabled.")
+                    elif (test == 1):
                         print("Just testing against an existing database, won\'t update anything.")
                         if (args.log):
                             writeToLog("\nJust testing against an existing database, won\'t update anything.")
@@ -1320,29 +1348,28 @@ def run_from_command_line():
                         if (args.log):
                             writeToLog("\nOnly comparing recently modified or accessed data.")
                     else:
-                        print("Invalid test option selected: {}. Using default level 0.".format(args.test))
+                        print("Invalid test option selected: {}. Using default level 0: testing-only disabled.".format(args.test))
                         if (args.log):
-                             writeToLog("\nInvalid test option selected: {}. Using default level 0.".format(args.test))
+                             writeToLog("\nInvalid test option selected: {}. Using default level 0: testing-only disabled.".format(args.test))
                         test = 0
-            elif (test == 0):
+            except Exception as err:
                 if (verbosity):
-                    print("Testing-only disabled.")
+                    print("Invalid test option selected: {}. Using default level 0: testing-only disabled.".format(args.test))
                     if (args.log):
-                        writeToLog("\nTesting-only disabled.")
-        except Exception as err:
-            if (verbosity):
-                print("Invalid test option selected: {}. Using default level 0.".format(args.test))
-                if (args.log):
-                     writeToLog("\nInvalid test option selected: {}. Using default level 0.".format(args.test))
-            test = 0
-            pass
+                         writeToLog("\nInvalid test option selected: {}. Using default level 0: testing-only disabled.".format(args.test))
+                test = 0
+                pass
 
         fix = 0
-        try:
-            fix = int(args.fix)
-            if (fix):
+        if (args.fix):
+            try:
+                fix = int(args.fix)
                 if (verbosity):
-                    if (fix == 1):
+                    if (fix == 0):
+                        print("Will not check problem files.")
+                        if (args.log):
+                            writeToLog("\nWill not check problem files.")
+                    elif (fix == 1):
                         print("Just checking files for problems; won\'t change anything.")
                         if (args.log):
                             writeToLog("\nJust checking files for problems; won\'t change anything.")
@@ -1355,18 +1382,13 @@ def run_from_command_line():
                         if (args.log):
                              writeToLog("\nInvalid test option selected: {}. Using default level 1; just checking files for problems, won\'t change anything.".format(args.fix))
                         fix = 1
-            elif (fix == 0):
-                    if (verbosity):
-                        print("Will not check problem files.")
-                        if (args.log):
-                            writeToLog("\nWill not check problem files.")
-        except Exception as err:
-            if (verbosity):
-                print("Invalid test option selected: {}. Using default level 1; just checking files for problems, won\'t change anything.".format(args.fix))
-                if (args.log):
-                     writeToLog("\nInvalid test option selected: {}. Using default level 1; just checking files for problems, won\'t change anything.".format(args.fix))
-            fix = 0
-            pass
+            except Exception as err:
+                if (verbosity):
+                    print("Invalid test option selected: {}. Using default level 1; just checking files for problems, won\'t change anything.".format(args.fix))
+                    if (args.log):
+                         writeToLog("\nInvalid test option selected: {}. Using default level 1; just checking files for problems, won\'t change anything.".format(args.fix))
+                fix = 0
+                pass
 
         bt = Bitrot(
             verbosity = verbosity,
@@ -1390,8 +1412,8 @@ def run_from_command_line():
         except BitrotException as bre:
             print('Error:', bre.args[1], file=sys.stderr)
             if (args.log):
-                writeToLog(stringToWrite='\nError: ')
-                writeToLog(stringToWrite=bre.args[1])
+                writeToLog('\nError: ')
+                writeToLog(bre.args[1])
             sys.exit(bre.args[0])
 
         #if include_list:

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -232,7 +232,6 @@ def list_existing_paths(directory, expected=(), ignored=(), included=(),
 class BitrotException(Exception):
     pass
 
-
 class Bitrot(object):
     def __init__(
         self, verbosity=1, email = False, log = False, test=0, follow_links=False, commit_interval=300,
@@ -289,9 +288,12 @@ class Bitrot(object):
         renamed_paths = []
         errors = []
         emails = []
+        emails.append([])
+        emails.append([])
         tooOldList = []
         warnings = []
         current_size = 0
+                
         missing_paths = self.select_all_paths(cur)
         #if self.include_list:
         #    paths = [line.rstrip('\n').encode(FSENCODING)
@@ -385,9 +387,6 @@ class Bitrot(object):
                 continue
             stored_mtime, stored_hash, stored_ts = row
 
-
-
-
             if (int(stored_mtime) != new_mtime) and not (self.test >= 2):
                 updated_paths.append(p)
                 cur.execute('UPDATE bitrot SET mtime=?, hash=?, timestamp=? '
@@ -397,9 +396,7 @@ class Bitrot(object):
                 continue
             if stored_hash != new_hash:
                 errors.append(p)
-                
-                emails.append([])
-                emails.append([])
+
                 emails[FIMErrorCounter].append(self.hashing_function)
                 emails[FIMErrorCounter].append(p.decode(FSENCODING))
                 emails[FIMErrorCounter].append(stored_hash)
@@ -429,7 +426,7 @@ class Bitrot(object):
                     emailToSendString +="Error {} mismatch for {} \nExpected {}\nGot:          {}\n".format(emails[i][0],emails[i][1],emails[i][2],emails[i][3])
                     emailToSendString +="Last good hash checked on {}\n\n".format(emails[i][4])
                 sendMail(emailToSendString,log=self.log,verbosity=self.verbosity, subject="FIM Error")
-
+            
         for path in missing_paths:
             cur.execute('DELETE FROM bitrot WHERE path=?', (path,))
 
@@ -511,7 +508,6 @@ class Bitrot(object):
         sys.stdout.write(size_fmt + ' ' + current_path)
         sys.stdout.flush()
         self._last_reported_size = size_fmt
-
 
     def report_done(
         self, total_size, all_count, error_count, warning_count, new_paths, updated_paths,
@@ -609,7 +605,6 @@ class Bitrot(object):
                             print("  {}".format(row))
                             if (self.log):
                                 writeToLog("  \n{}".format(row))
-
 
             if new_paths:
                 if (len(new_paths) == 1):
@@ -723,7 +718,6 @@ class Bitrot(object):
 def get_path(directory=b'.', ext=b'db'):
     """Compose the path to the selected bitrot file."""
     return os.path.join(directory, b'.bitrot.' + ext)
-
 
 def stable_sum(bitrot_db=None):
     """Calculates a stable SHA512 of all entries in the database.
@@ -930,7 +924,6 @@ def pathStripper(pathToStrip="",sfv=""):
     if (sfv == "MD5"):
         pathToStripString = "*" + pathToStripString
     return pathToStripString
-
 
 def run_from_command_line():
     global FSENCODING

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -372,24 +372,19 @@ class Bitrot(object):
         current_size = 0
                 
         missing_paths = self.select_all_paths(cur)
-        #if self.include_list:
-        #    paths = [line.rstrip('\n').encode(FSENCODING)
-        #        for line in self.include_list.readlines()]
-        #    total_size = sum([os.path.getsize(filename) for filename in paths])
-        #else:
 
        
 
-        if (self.fix == True):
-            fixedRenameList, fixedRenameCounter = fix_existing_paths(
-            os.getcwd(),# pass an unambiguous string instead of: b'.'  
-            verbosity=self.verbosity,
-            log=self.log,
-            fix=self.fix,
-            warnings=warnings,
-            fixedRenameList = fixedRenameList,
-            fixedRenameCounter = fixedRenameCounter
-        )
+        # if (self.fix == True):
+        #     fixedRenameList, fixedRenameCounter = fix_existing_paths(
+        #     os.getcwd(),# pass an unambiguous string instead of: b'.'  
+        #     verbosity=self.verbosity,
+        #     log=self.log,
+        #     fix=self.fix,
+        #     warnings=warnings,
+        #     fixedRenameList = fixedRenameList,
+        #     fixedRenameCounter = fixedRenameCounter
+        # )
 
 
         paths, total_size, ignoredList = list_existing_paths(
@@ -469,7 +464,7 @@ class Bitrot(object):
                     tooOldList.append(p_uni)
                     missing_paths.discard(p_uni)
                     total_size -= st.st_size
-                continue
+                    continue
 
             current_size += st.st_size
             if self.verbosity:

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -60,13 +60,13 @@ if sys.version[0] == '2':
 def sendMail(stringToSend="", log=1, verbosity=1, subject=""):
     msg = MIMEText(stringToSend)
 
-    DEFAULT_CHUNK_SIZE = 16384  # block size in HFS+; 4X the block size in ext4
-    DOT_THRESHOLD = 2
-    VERSION = (0, 9, 3)
-    IGNORED_FILE_SYSTEM_ERRORS = {errno.ENOENT, errno.EACCES}
-    FSENCODING = sys.getfilesystemencoding()
-    DEFAULT_HASH_FUNCTION = "SHA512" 
-
+      FROMADDR = 'author@gmail.com'
+      TOADDR  = 'recipient@gmail.com'
+      msg['To'] = email.utils.formataddr(('Recipient', 'recipient@gmail.com'))
+      msg['From'] = email.utils.formataddr(('Author', 'recipient@gmail.com'))
+      USERNAME = 'authorUsername'
+      PASSWORD = 'authorPassword'
+    
     try:
         msg['Subject'] = subject
         # The actual mail send
@@ -691,7 +691,16 @@ class Bitrot(object):
             if (self.log):
                 writeToLog(' {} warnings found.'.format(warning_count))
 
-        if self.verbosity == 1:
+
+        # help='Level 0: Don\'t print anything besides checksum errors.\n'
+        # 'Level 1: Normal amount of verbosity.\n'
+        # 'Level 2: List missing, and fixed entries.\n'
+        # 'Level 3: List missing, fixed, new, renamed, and updated entries.\n'
+        # 'Level 4: List missing, fixed, new, renamed, and updated entries, and ignored files.\n')
+
+
+
+        if self.verbosity >= 1:
             if (all_count == 1):
                 print(
                     '1 entry in the database, {} new, {} updated, '
@@ -717,15 +726,15 @@ class Bitrot(object):
                         all_count, len(new_paths), len(updated_paths),
                         len(renamed_paths), len(missing_paths), len(tooOldList), totalFixed))
 
-        elif self.verbosity > 1:
-            if (all_count == 1):
-                print('1 entry in the database.')
-                if (self.log):
-                    writeToLog('1 entry in the database.')
-            else:
-                print('{} entries in the database.'.format(all_count), end=' ')
-                if (self.log):
-                    writeToLog('\n{} entries in the database.'.format(all_count))
+        # if self.verbosity >= 2:
+        #     if (all_count == 1):
+        #         print('1 entry in the database.')
+        #         if (self.log):
+        #             writeToLog('1 entry in the database.')
+        #     else:
+        #         print('{} entries in the database.'.format(all_count), end=' ')
+        #         if (self.log):
+        #             writeToLog('\n{} entries in the database.'.format(all_count))
 
         if self.verbosity >= 4:
             if (ignoredList):
@@ -1214,17 +1223,33 @@ def run_from_command_line():
         if args.verbose:
             try:
                 verbosity = int(args.verbose)
+                if (verbosity == 1):
+                    print("Verbosity option selected: {}. Normal amount of verbosity.".format(args.verbose))
+                    if (args.log):
+                         writeToLog("\nVerbosity option selected: {}. Normal amount of verbosity.".format(args.verbose))
+                elif (verbosity == 2):
+                    print("Verbosity option selected: {}. List missing, and fixed entries.".format(args.verbose))
+                    if (args.log):
+                         writeToLog("\nVerbosity option selected: {}. List missing, and fixed entries.".format(args.verbose))
+                elif (verbosity == 3):
+                    print("Verbosity option selected: {}. List missing, fixed, new, renamed, and updated entries.".format(args.verbose))
+                    if (args.log):
+                         writeToLog("\nVerbosity option selected: {}. List missing, fixed, new, renamed, and updated entries.".format(args.verbose))
+                elif (verbosity == 4):
+                    print("Verbosity option selected: {}. List missing, fixed, new, renamed, and updated entries, and ignored files.".format(args.verbose))
+                    if (args.log):
+                         writeToLog("\nVerbosity option selected: {}. List missing, fixed, new, renamed, and updated entries, and ignored files.".format(args.verbose))
+                elif not (verbosity == 0):
+                    print("Invalid verbosity option selected: {}. Using default level 1.".format(args.verbose))
+                    if (args.log):
+                         writeToLog("\nInvalid test option selected: {}. Using default level 1.".format(args.verbose))
+                    verbosity = 1
             except Exception as err:
                 print("Invalid verbosity option selected: {}. Using default level 1.".format(args.verbose))
                 if (args.log):
                      writeToLog("\nInvalid test option selected: {}. Using default level 1.".format(args.verbose))
                 verbosity = 1
                 pass
-            if (verbosity != 0 and verbosity != 1 and verbosity != 2 and verbosity != 3 and verbosity != 4):
-                print("Invalid verbosity option selected: {}. Using default level 1.".format(args.verbose))
-                if (args.log):
-                     writeToLog("\nInvalid test option selected: {}. Using default level 1.".format(args.verbose))
-                verbosity = 1
 
         if (args.log):
             log_path = get_path(ext=b'log')

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -674,13 +674,13 @@ class Bitrot(object):
         sizeUnits , total_size = calculateUnits(total_size=total_size)
         totalFixed = fixedRenameCounter + fixedPropertiesCounter
         if (error_count == 1):
-                print('\rFinished. {:.2f} {} of data read. 1 error found. '.format(total_size,sizeUnits),end="")
+                print('\rFinished. {:.2f} {} of data read. 1 error found.'.format(total_size,sizeUnits),end="")
                 if (self.log):
-                    writeToLog('\n\nFinished. {:.2f} {} of data read. '.format(total_size,sizeUnits))
+                    writeToLog('\n\nFinished. {:.2f} {} of data read. 1 error found.'.format(total_size,sizeUnits))
         else:
-            print('\rFinished. {:.2f} {} of data read. {} errors found. '.format(total_size, sizeUnits, error_count),end="")
+            print('\rFinished. {:.2f} {} of data read. {} errors found.'.format(total_size, sizeUnits, error_count),end="")
             if (self.log):
-                writeToLog('\n\nFinished. {:.2f} MiB of data read. {} errors found. '.format(total_size, error_count, sizeUnits))
+                writeToLog('\n\nFinished. {:.2f} {} of data read. {} errors found.'.format(total_size, sizeUnits, error_count))
 
         if (warning_count == 1):
             print('1 warning found.')
@@ -1250,6 +1250,9 @@ def run_from_command_line():
                     for line in includeFile:
                         line = line.rstrip('\n').encode(FSENCODING)
                         include_list.append(line)
+                    if includeFile:
+                        includeFile.close() # should be harmless if include_list == sys.stdin
+
             except Exception as err:
                 if (verbosity):
                     print("Invalid inclusion list specified: `{}`. Not using an inclusion list. Received error: {}".format(args.include_list, err))
@@ -1270,6 +1273,8 @@ def run_from_command_line():
                     for line in excludeFile:
                         line = line.rstrip('\n').encode(FSENCODING)
                         exclude_list.append(line)
+                    if excludeFile:
+                        excludeFile.close() # should be harmless if include_list == sys.stdin
             except Exception as err:
                 if (verbosity):
                     print("Invalid exclusion list specified: `{}`. Not using an exclusion list. Received error: {}".format(args.exclude_list, err))
@@ -1421,12 +1426,6 @@ def run_from_command_line():
                 writeToLog('\nError: ')
                 writeToLog(bre.args[1])
             sys.exit(bre.args[0])
-
-        if includeFile:
-            includeFile.close() # should be harmless if include_list == sys.stdin
-
-        #if excludeFile:
-            # excludeFile.close() # should be harmless if include_list == sys.stdin
 
 if __name__ == '__main__':
     run_from_command_line()

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -42,7 +42,7 @@ import smtplib
 from fnmatch import fnmatch
 import email.utils
 from email.mime.text import MIMEText
-from datetime import timedelta
+#from datetime import timedelta
 import binascii
 #import re
 
@@ -211,20 +211,6 @@ def list_existing_paths(directory, expected=(), ignored=(), included=(),
                 include_this = [fnmatch(file.encode(FSENCODING), wildcard) 
                                 for file in p.decode(FSENCODING).split(os.path.sep)
                                 for wildcard in included]                
-              #  if included:
-              #      if  any(include_this) or any([fnmatch(p, exc) for exc in included]):
-              #          print("Found good shit: {}".format(p.decode(FSENCODING)))
-              #      else:
-              #          if verbosity > 2:
-              #              #print('Ignoring file: {}'.format(p))
-              #             print('Ignoring file: {}'.format(p.decode(FSENCODING)))
-              #             if (log):
-              #                  #writeToLog(stringToWrite="\nIgnoring file: {}".format(p))
-              #                  writeToLog(stringToWrite="\nIgnoring file: {}".format(p.decode(FSENCODING)))
-              #          continue
-              #  if ((included) and (not any([fnmatch(p, exc) for exc in included]) or not any(include_this))):
-              #      print("Found bad shit: {}".format(p.decode(FSENCODING)))
-              #      return
 
                 if not stat.S_ISREG(st.st_mode) or any(exclude_this) or any([fnmatch(p, exc) for exc in ignored]) or (included and not any([fnmatch(p, exc) for exc in included]) and not any(include_this)):
                 #if not stat.S_ISREG(st.st_mode) or any([fnmatch(p, exc) for exc in ignored]):
@@ -384,6 +370,8 @@ class Bitrot(object):
                     missing_paths.discard(stored_path)
                 continue
             stored_mtime, stored_hash, stored_ts = row
+
+        
             if (int(stored_mtime) != new_mtime) and (self.no_time == False):
                 updated_paths.append(p)
                 cur.execute('UPDATE bitrot SET mtime=?, hash=?, timestamp=? '
@@ -984,9 +972,15 @@ def run_from_command_line():
                     writeToLog(stringToWrite='======================================================\n')
                 writeToLog(stringToWrite='Log started at ')
                 writeToLog(stringToWrite=datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
+
+        no_time = False
+        test = False 
         if args.no_time:
-            no_time = 1
-            args.test = 1
+            no_time = True
+            test = True
+        elif args.test:
+            test = True
+
         if args.include_list == '-':
             if verbosity:
                 print('Using stdin for file list')
@@ -1067,10 +1061,10 @@ def run_from_command_line():
         bt = Bitrot(
             verbosity=verbosity,
             hashing_function=hashing_function,
-            test=args.test,
+            test=test,
             email=args.email,
             log = args.log,
-            no_time = args.no_time,
+            no_time = no_time,
             follow_links=args.follow_links,
             commit_interval=args.commit_interval,
             chunk_size=args.chunk_size,

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -1216,9 +1216,9 @@ def run_from_command_line():
             include_list = []
         if args.exclude_list:
             if verbosity:
-                print('Opening exclude list in', args.exclude_list)
+                print('Opening file exclusion list at', args.exclude_list)
                 if (args.log):
-                    writeToLog(stringToWrite='\nOpening exclude list in')
+                    writeToLog(stringToWrite='\nOpening file exclusion list at')
                     writeToLog(stringToWrite=args.exclude_list)
             exclude_list = [line.rstrip('\n').encode(FSENCODING) for line in open(args.exclude_list)]
         else:

--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -60,13 +60,13 @@ if sys.version[0] == '2':
 def sendMail(stringToSend="", log=1, verbosity=1, subject=""):
     msg = MIMEText(stringToSend)
 
-      FROMADDR = 'author@gmail.com'
-      TOADDR  = 'recipient@gmail.com'
-      msg['To'] = email.utils.formataddr(('Recipient', 'recipient@gmail.com'))
-      msg['From'] = email.utils.formataddr(('Author', 'recipient@gmail.com'))
-      USERNAME = 'authorUsername'
-      PASSWORD = 'authorPassword'
-    
+    FROMADDR = 'author@gmail.com'
+    TOADDR  = 'recipient@gmail.com'
+    msg['To'] = email.utils.formataddr(('Recipient', 'recipient@gmail.com'))
+    msg['From'] = email.utils.formataddr(('Author', 'recipient@gmail.com'))
+    USERNAME = 'authorUsername'
+    PASSWORD = 'authorPassword'
+
     try:
         msg['Subject'] = subject
         # The actual mail send
@@ -1198,10 +1198,10 @@ def run_from_command_line():
         'Level 3: List missing, fixed, new, renamed, and updated entries.\n'
         'Level 4: List missing, fixed, new, renamed, and updated entries, and ignored files.\n')
     parser.add_argument(
-        '-e', '--email', action='store_true',
+        '-e', '--email', default=1,
         help='email file integrity errors')
     parser.add_argument(
-        '-g', '--log', action='store_true',
+        '-g', '--log', default=1,
         help='logs activity')
     parser.add_argument(
         '-c', '--sfv', default='',
@@ -1223,11 +1223,7 @@ def run_from_command_line():
         if args.verbose:
             try:
                 verbosity = int(args.verbose)
-                if (verbosity == 1):
-                    print("Verbosity option selected: {}. Normal amount of verbosity.".format(args.verbose))
-                    if (args.log):
-                         writeToLog("\nVerbosity option selected: {}. Normal amount of verbosity.".format(args.verbose))
-                elif (verbosity == 2):
+                if (verbosity == 2):
                     print("Verbosity option selected: {}. List missing, and fixed entries.".format(args.verbose))
                     if (args.log):
                          writeToLog("\nVerbosity option selected: {}. List missing, and fixed entries.".format(args.verbose))
@@ -1239,7 +1235,7 @@ def run_from_command_line():
                     print("Verbosity option selected: {}. List missing, fixed, new, renamed, and updated entries, and ignored files.".format(args.verbose))
                     if (args.log):
                          writeToLog("\nVerbosity option selected: {}. List missing, fixed, new, renamed, and updated entries, and ignored files.".format(args.verbose))
-                elif not (verbosity == 0):
+                elif not (verbosity == 0) and not (verbosity == 1):
                     print("Invalid verbosity option selected: {}. Using default level 1.".format(args.verbose))
                     if (args.log):
                          writeToLog("\nInvalid test option selected: {}. Using default level 1.".format(args.verbose))


### PR DESCRIPTION
* Added database vacuuming to shrink DB size on hard drive of old hashes that went missing
* Added logging to file using -g or ---log (on by default)
* Added grammar fixes
* Added a time elapsed counter
* Added email support for hash mismatch using -e or --email (on by default)
* Added option to ignore date modified (only checks hashes). Great for verifying backups for integrity (File Integrity Monitoring) using -t 2 or --test 2
* Added ability to specify hash function from command line. I found SHA512 to be just as fast as SHA1 on my machine using -a or --hashing-function
* Total size now printed in B, KB, MB, GB, TB
* Fixes for invalid characters in file names
* Better warning printing
* Integrates benshep's and liloman's latest changes
* Can now include and exclude at same time, and fixed logic. Exclude takes prescendence
* Now prints out ignored files at the end with verbosity level 4
* Added option to allow testing of only recent (default: last 1 day) of recently modified data (great for checking a backup you just synced for integrity) using -r or --recent
* Fixed bug when file doesn't have a valid modification timestamp
* Can now fix files that have invalid modification date, and rename files/dirs that have bad chars in name, using -f or --fix (dangerous)
* Can now create MD5 or SFV files using -c or --sfv