### PR TITLE
Normalize unicode paths in the database

### DIFF
--- a/src/bitrot.py
+++ b/src/bitrot.py
@@ -32,7 +32,6 @@ import datetime
 import errno
 import hashlib
 import os
-import re
 import shutil
 import sqlite3
 import stat
@@ -55,7 +54,7 @@ if sys.version[0] == '2':
 
 
 def normalize_path(path):
-    if re.search('utf-8', FSENCODING, re.I):
+    if FSENCODING == 'utf-8' or FSENCODING == 'UTF-8':
         return unicodedata.normalize('NFKC', path)
     else:
         return path


### PR DESCRIPTION
Hello! 

I have the same set of files synced across linux and mac machines.

I run bitrot tool on one machine (mac). It saves chechsums into the database. After that I tried to run bitrot tool on another machine (linux). It went well for most of the files but it was reported that hundreds of them are new and hundreds of them can no longer be found.

It turns out I have funny unicode characters in file names. Those characters are stored differently on different file systems.

One particular case is filenames "Йод.txt" and "Йод.txt". That's two identical files, one is on mac, another is on linux. They looks the same but they are composed using different unicode methods. As my sync software moves the file between machines then the exact bytecode of filenames is changed.

To keep track of those kind of files across machines I propose to normalize unicode filenames before they are stored in the database. This pull request implements that.

I'm not sure if I will be able to write tests, as I'm not well familiar with Python.

Thank you.