### PR TITLE
require python>=3.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .bitrot.db
 .bitrot.sha512
+
+_version.py
+
+__pycache__
+*.egg-info

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Change Log
 ~~~~~
 
 * officially remove Python 2 support that was broken since 1.0.0
-  anyway; now the package works with Python 3.8+ because of a few
+  anyway; now the package works with Python 3.9+ because of a few
   features
 
 1.0.0

--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Change Log
 ~~~~~
 
 * officially remove Python 2 support that was broken since 1.0.0
-  anyway; now the package works with Python 3.9+ because of a few
+  anyway; now the package works with Python 3.8+ because of a few
   features
 
 1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm[toml]"]
+requires = ["setuptools", "setuptools_scm[toml]"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -31,4 +31,4 @@ test = ["pytest", "pytest-order"]
 bitrot = "bitrot:run_from_command_line"
 
 [tool.setuptools_scm]
-tag_regex = "^(?P<version>v\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$"
+write_to = '_version.py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Detects bit rotten files on the hard drive to save your precious photo and music collection from slow decay."
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 keywords = ["file", "checksum", "database"]
 license = {text = "MIT"}
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 description = "Detects bit rotten files on the hard drive to save your precious photo and music collection from slow decay."
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["file", "checksum", "database"]
 license = {text = "MIT"}
 classifiers = [

--- a/tests/test_bitrot.py
+++ b/tests/test_bitrot.py
@@ -15,13 +15,14 @@ from textwrap import dedent
 
 import pytest
 
+from typing import TYPE_CHECKING
 
 TMP = Path("/tmp/")
 
-
-ReturnCode = int
-StdOut = list[str]
-StdErr = list[str]
+if TYPE_CHECKING:
+    ReturnCode = int
+    StdOut = list[str]
+    StdErr = list[str]
 
 
 def bitrot(*args: str) -> tuple[ReturnCode, StdOut, StdErr]:


### PR DESCRIPTION
The syntax in `tests/test_bitrot.py`
```
StdOut = list[str]
StdErr = list[str]
```
was implemented in 3.9 for the first time.